### PR TITLE
Allow gatekeeper to run in any namespace

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Deploy Gatekeeper Operator
       run: |
         make install
-        make deploy IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+        make deploy NAMESPACE=mygatekeeper IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
 
     - name: E2E Tests
       run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ REPO ?= quay.io/gatekeeper
 BUNDLE_IMG ?= $(REPO)/gatekeeper-operator-bundle:$(VERSION)
 # Default bundle index image tag
 BUNDLE_INDEX_IMG ?= $(REPO)/gatekeeper-operator-bundle-index:$(VERSION)
+# Default namespace
+NAMESPACE ?= gatekeeper-system
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
@@ -98,6 +100,7 @@ uninstall: manifests kustomize
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
 deploy: manifests kustomize
+	cd config/default && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ registry service like [quay.io](https://quay.io).
     make deploy IMG=<registry>/<imagename>:<tag>
     ```
 
+You can also specify in which namespace you want the operator to be deployed to by
+providing the `NAMESPACE` variable. If not provided the default namespace will be 
+`gatekeeper-system`.
+
+```shell
+make deploy IMG=<registry>/<imagename>:tag NAMESPACE=mygatekeeper
+```
+
 ### Deploy Operator using OLM
 
 If you would like to deploy Operator using OLM, you'll need to build and push the bundle image and index image. You need to host the images on a public registry service like [quay.io](https://quay.io).

--- a/test/gatekeeper_controller_test.go
+++ b/test/gatekeeper_controller_test.go
@@ -48,7 +48,7 @@ const (
 	waitTimeout = 30 * time.Second
 	// Gatekeeper name and namespace
 	gkName      = "gatekeeper"
-	gkNamespace = "gatekeeper-system"
+	gkNamespace = "mygatekeeper"
 )
 
 var (
@@ -254,7 +254,7 @@ var _ = Describe("Gatekeeper", func() {
 
 		It("Contains the configured values", func() {
 			gatekeeper := &v1alpha1.Gatekeeper{}
-			gatekeeper.Namespace = "gatekeeper-system"
+			gatekeeper.Namespace = gkNamespace
 			err := loadGatekeeperFromFile(gatekeeper, "gatekeeper_with_all_values.yaml")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())


### PR DESCRIPTION
Fix #51 

Sets the current namespace to any namespaced object and any object that has a reference to the namespace will be overridden during the reconciliation.

The objects having references to the namespace are the following:
* clusterrolebinding:subject
* rolebinding:subject
* controller-manager:exept-namespace container argument
* validatingWebhook:clientConfig

In case there were multiple namespaces running the gatekeeper operator, the cluster-scoped objects might need to be updated in order to add a new clientConfig to the validatingWebhookConfiguration and more subjects to the clusterRoleBinding.

Signed-off-by: ruromero <rromerom@redhat.com>