### PR TITLE
Rename operator image to gatekeeper-operator

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,5 +27,5 @@ jobs:
         pull: true
         push: true
         tags: |
-          quay.io/gatekeeper/operator:latest
-          quay.io/gatekeeper/operator:master
+          quay.io/gatekeeper/gatekeeper-operator:latest
+          quay.io/gatekeeper/gatekeeper-operator:master

--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -52,7 +52,7 @@ type GatekeeperSpec struct {
 
 type ImageConfig struct {
 	// Image to pull including registry (optional), repository, name, and tag
-	// e.g. quay.io/gatekeeper/operator:latest
+	// e.g. quay.io/gatekeeper/gatekeeper-operator:latest
 	// +optional
 	Image *string `json:"image,omitempty"`
 	// +optional

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -221,7 +221,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/gatekeeper/operator:latest
+                image: quay.io/gatekeeper/gatekeeper-operator:latest
                 imagePullPolicy: Always
                 name: manager
                 resources:

--- a/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
@@ -412,7 +412,7 @@ spec:
               image:
                 properties:
                   image:
-                    description: Image to pull including registry (optional), repository, name, and tag e.g. quay.io/gatekeeper/operator:latest
+                    description: Image to pull including registry (optional), repository, name, and tag e.g. quay.io/gatekeeper/gatekeeper-operator:latest
                     type: string
                   imagePullPolicy:
                     description: PullPolicy describes a policy for if/when to pull a container image

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -669,7 +669,7 @@ spec:
                 properties:
                   image:
                     description: Image to pull including registry (optional), repository,
-                      name, and tag e.g. quay.io/gatekeeper/operator:latest
+                      name, and tag e.g. quay.io/gatekeeper/gatekeeper-operator:latest
                     type: string
                   imagePullPolicy:
                     description: PullPolicy describes a policy for if/when to pull

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/gatekeeper/operator
+  newName: quay.io/gatekeeper/gatekeeper-operator
   newTag: latest


### PR DESCRIPTION
This is future proofing the image name to make sure we don't have to rename it in the future that may cause confusion and inconsistencies if we already have a released version of the operator. The thinking is that if we ever need to publish the operator image to another registry repo e.g. `docker.io/openpolicyagent`, the `operator` image name can be ambiguous and confusing. This change makes it more clear by renaming the image to `gatekeeper-operator`.