### PR TITLE
Cluster scoped operator and custom resource

### DIFF
--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -169,6 +169,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=gatekeepers,scope=Cluster
 //// +kubebuilder:printcolumn:name="Audit Status",type=string,JSONPath=`.status.auditConditions[0].type`,description="The status of the Gatekeeper Audit"
 //// +kubebuilder:printcolumn:name="Webhook Status",type=string,JSONPath=`.status.webhookConditions[0].type`,description="The status of the Gatekeeper Webhook"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -114,6 +114,26 @@ spec:
           - update
           - watch
         - apiGroups:
+          - operator.gatekeeper.sh
+          resources:
+          - gatekeepers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.gatekeeper.sh
+          resources:
+          - gatekeepers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - policy
           resources:
           - podsecuritypolicies
@@ -298,35 +318,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - operator.gatekeeper.sh
-          resources:
-          - gatekeepers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.gatekeeper.sh
-          resources:
-          - gatekeepers/finalizers
-          verbs:
-          - delete
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.gatekeeper.sh
-          resources:
-          - gatekeepers/status
-          verbs:
-          - get
-          - patch
-          - update
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: GatekeeperList
     plural: gatekeepers
     singular: gatekeeper
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: GatekeeperList
     plural: gatekeepers
     singular: gatekeeper
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp

--- a/config/rbac/base/role.yaml
+++ b/config/rbac/base/role.yaml
@@ -85,15 +85,6 @@ rules:
 - apiGroups:
   - operator.gatekeeper.sh
   resources:
-  - gatekeepers/finalizers
-  verbs:
-  - delete
-  - get
-  - patch
-  - update
-- apiGroups:
-  - operator.gatekeeper.sh
-  resources:
   - gatekeepers/status
   verbs:
   - get

--- a/config/rbac/base/role.yaml
+++ b/config/rbac/base/role.yaml
@@ -71,6 +71,35 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.gatekeeper.sh
+  resources:
+  - gatekeepers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.gatekeeper.sh
+  resources:
+  - gatekeepers/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - operator.gatekeeper.sh
+  resources:
+  - gatekeepers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - policy
   resources:
   - podsecuritypolicies
@@ -168,35 +197,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - operator.gatekeeper.sh
-  resources:
-  - gatekeepers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - operator.gatekeeper.sh
-  resources:
-  - gatekeepers/finalizers
-  verbs:
-  - delete
-  - get
-  - patch
-  - update
-- apiGroups:
-  - operator.gatekeeper.sh
-  resources:
-  - gatekeepers/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/main.go
+++ b/main.go
@@ -76,9 +76,10 @@ func main() {
 	}
 
 	if err = (&controllers.GatekeeperReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Gatekeeper"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("Gatekeeper"),
+		Scheme:    mgr.GetScheme(),
+		Namespace: watchNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gatekeeper")
 		os.Exit(1)

--- a/test/gatekeeper_controller_test.go
+++ b/test/gatekeeper_controller_test.go
@@ -136,6 +136,9 @@ var _ = Describe("Gatekeeper", func() {
 					Eventually(func() error {
 						return K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
 					}, waitTimeout, pollInterval).ShouldNot(HaveOccurred())
+					Expect(validatingWebhookConfiguration.OwnerReferences).To(HaveLen(1))
+					Expect(validatingWebhookConfiguration.OwnerReferences[0].Kind).To(Equal("Gatekeeper"))
+					Expect(validatingWebhookConfiguration.OwnerReferences[0].Name).To(Equal(gkName))
 				})
 			})
 		})


### PR DESCRIPTION
Fix #70 

Signed-off-by: ruromero <rromerom@redhat.com>

I think the included changes should cover the most common use cases.
The operator uses the WATCHED_NAMESPACE to decide where to deploy the namespaced objects like the Server Cert Secret but the Gatekeeper resource is now clustered.

As the operator currently only allows for Gatekeeper resources with name `gatekeeper` it should avoid conflicts.