### PR TITLE
use openshift csv in bundle by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ IMG ?= $(REPO)/gatekeeper-operator:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 GATEKEEPER_MANIFEST_DIR ?= config/gatekeeper
+OPENSHIFT_RBAC_DIR = config/rbac/overlays/openshift
 
 ifeq (openshift, $(KUBE_DISTRIBUTION))
-RBAC_DIR=config/rbac/overlays/openshift
+RBAC_DIR=$(OPENSHIFT_RBAC_DIR)
 else
 RBAC_DIR=config/rbac/base
 endif
@@ -257,7 +258,7 @@ $(OPERATOR_SDK):
 bundle: operator-sdk manifests
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	{ $(KUSTOMIZE) build config/manifests ; echo "---" ; $(KUSTOMIZE) build $(RBAC_DIR) ; } | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	{ $(KUSTOMIZE) build config/manifests ; echo "---" ; $(KUSTOMIZE) build $(OPENSHIFT_RBAC_DIR) ; } | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Build the bundle image.

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -177,6 +177,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - anyuid
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews


### PR DESCRIPTION
fixes permissions issue on openshift without having to build a separate image. tested on my cluster and it works the same as the image I created using `make bundle KUBE_DISTRIBUTION=openshift`