### PR TITLE
use v1 for the metrics-reader ClusterRole object

### DIFF
--- a/config/rbac/base/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/base/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
It's using v1beta1 which has been deprecated for a while now. Let's use
v1 instead.