### PR TITLE
Enable manager role to modify operator finalizers

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -128,6 +128,15 @@ spec:
         - apiGroups:
           - operator.gatekeeper.sh
           resources:
+          - gatekeepers/finalizers
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.gatekeeper.sh
+          resources:
           - gatekeepers/status
           verbs:
           - get

--- a/config/rbac/base/role.yaml
+++ b/config/rbac/base/role.yaml
@@ -85,6 +85,15 @@ rules:
 - apiGroups:
   - operator.gatekeeper.sh
   resources:
+  - gatekeepers/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - operator.gatekeeper.sh
+  resources:
   - gatekeepers/status
   verbs:
   - get

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -97,6 +97,7 @@ type GatekeeperReconciler struct {
 // Gatekeeper Operator RBAC permissions to manager Gatekeeper custom resource
 // +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers/finalizers,verbs=delete;get;update;patch
 
 // Gatekeeper Operator RBAC permissions to deploy Gatekeeper. Many of these
 // RBAC permissions are needed because the operator must have the permissions


### PR DESCRIPTION
This permission was missing and was causing issues when deploying the
Gatekeeper resource as the manager couldn't set the onwer references
to other objects.

Closes #88