### PR TITLE
Fix installing Gatekeeper when operator is deployed via OLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ manifests: controller-gen
 .PHONY: import-manifests
 import-manifests: kustomize
 	$(KUSTOMIZE) build github.com/open-policy-agent/gatekeeper/config/default/?ref=$(GATEKEEPER_VERSION) -o $(GATEKEEPER_MANIFEST_DIR)
-	rm -f ./$(GATEKEEPER_MANIFEST_DIR)/v1_namespace_gatekeeper-system.yaml
 
 # Run go fmt against code
 .PHONY: fmt

--- a/README.md
+++ b/README.md
@@ -29,18 +29,11 @@ Then proceed to the installation method you prefer below.
 
 ### Outside the Cluster
 
-If you would like to run the Operator outside the cluster, you'll have to set the
-`WATCH_NAMESPACE` environment variable to the namespace you want the
-Operator to monitor:
+If you would like to run the Operator outside the cluster you just execute:
 
-1. Set the WATCH_NAMESPACE environment variable:
-    ```shell
-    export WATCH_NAMESPACE=gatekeeper-system
-    ```
-1. You then run the Operator with:
-    ```shell
-    make run
-    ```
+```shell
+make run
+```
 
 ### Inside the Cluster
 

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -256,11 +256,6 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                env:
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/gatekeeper/gatekeeper-operator:latest
                 imagePullPolicy: Always
                 name: manager

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -206,6 +206,18 @@ spec:
           - patch
           - update
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - security.openshift.io
           resourceNames:
           - anyuid

--- a/config/gatekeeper/v1_namespace_gatekeeper-system.yaml
+++ b/config/gatekeeper/v1_namespace_gatekeeper-system.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    admission.gatekeeper.sh/ignore: no-self-managing
+    control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-system

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,9 +37,4 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        env:
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/config/rbac/overlays/openshift/kustomization.yaml
+++ b/config/rbac/overlays/openshift/kustomization.yaml
@@ -11,6 +11,21 @@ patchesJSON6902:
       path: /rules/-
       value:
         apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+    - op: add
+      path: /rules/-
+      value:
+        apiGroups:
           - security.openshift.io
         resourceNames:
           - anyuid

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,19 +55,12 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	watchNamespace, err := getWatchNamespace()
-	if err != nil {
-		setupLog.Error(err, "unable to get WatchNamespace, ")
-		os.Exit(1)
-	}
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "6ccdc528.gatekeeper.sh",
-		Namespace:          watchNamespace, // namespaced-scope when the value is not an empty string
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -79,7 +71,7 @@ func main() {
 		Client:    mgr.GetClient(),
 		Log:       ctrl.Log.WithName("controllers").WithName("Gatekeeper"),
 		Scheme:    mgr.GetScheme(),
-		Namespace: watchNamespace,
+		Namespace: namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Gatekeeper")
 		os.Exit(1)
@@ -91,19 +83,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-// getWatchNamespace returns the Namespace the operator should be watching for
-// changes.
-func getWatchNamespace() (string, error) {
-	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
-	// which specifies the Namespace to watch. An empty value means the
-	// operator is running with cluster scope.
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
-
-	ns, found := os.LookupEnv(watchNamespaceEnvVar)
-	if !found {
-		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
-	}
-	return ns, nil
 }

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -13,6 +13,7 @@
 // config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrolebinding_gatekeeper-manager-rolebinding.yaml
 // config/gatekeeper/rbac.authorization.k8s.io_v1_role_gatekeeper-manager-role.yaml
 // config/gatekeeper/rbac.authorization.k8s.io_v1_rolebinding_gatekeeper-manager-rolebinding.yaml
+// config/gatekeeper/v1_namespace_gatekeeper-system.yaml
 // config/gatekeeper/v1_secret_gatekeeper-webhook-server-cert.yaml
 // config/gatekeeper/v1_service_gatekeeper-webhook-service.yaml
 // config/gatekeeper/v1_serviceaccount_gatekeeper-admin.yaml
@@ -1132,6 +1133,31 @@ func configGatekeeperRbacAuthorizationK8sIo_v1_rolebinding_gatekeeperManagerRole
 	return a, nil
 }
 
+var _configGatekeeperV1_namespace_gatekeeperSystemYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    admission.gatekeeper.sh/ignore: no-self-managing
+    control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-system
+`)
+
+func configGatekeeperV1_namespace_gatekeeperSystemYamlBytes() ([]byte, error) {
+	return _configGatekeeperV1_namespace_gatekeeperSystemYaml, nil
+}
+
+func configGatekeeperV1_namespace_gatekeeperSystemYaml() (*asset, error) {
+	bytes, err := configGatekeeperV1_namespace_gatekeeperSystemYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/gatekeeper/v1_namespace_gatekeeper-system.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _configGatekeeperV1_secret_gatekeeperWebhookServerCertYaml = []byte(`apiVersion: v1
 kind: Secret
 metadata:
@@ -1277,6 +1303,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrolebinding_gatekeeper-manager-rolebinding.yaml":                                  configGatekeeperRbacAuthorizationK8sIo_v1_clusterrolebinding_gatekeeperManagerRolebindingYaml,
 	"config/gatekeeper/rbac.authorization.k8s.io_v1_role_gatekeeper-manager-role.yaml":                                                       configGatekeeperRbacAuthorizationK8sIo_v1_role_gatekeeperManagerRoleYaml,
 	"config/gatekeeper/rbac.authorization.k8s.io_v1_rolebinding_gatekeeper-manager-rolebinding.yaml":                                         configGatekeeperRbacAuthorizationK8sIo_v1_rolebinding_gatekeeperManagerRolebindingYaml,
+	"config/gatekeeper/v1_namespace_gatekeeper-system.yaml":                                                                                  configGatekeeperV1_namespace_gatekeeperSystemYaml,
 	"config/gatekeeper/v1_secret_gatekeeper-webhook-server-cert.yaml":                                                                        configGatekeeperV1_secret_gatekeeperWebhookServerCertYaml,
 	"config/gatekeeper/v1_service_gatekeeper-webhook-service.yaml":                                                                           configGatekeeperV1_service_gatekeeperWebhookServiceYaml,
 	"config/gatekeeper/v1_serviceaccount_gatekeeper-admin.yaml":                                                                              configGatekeeperV1_serviceaccount_gatekeeperAdminYaml,
@@ -1340,6 +1367,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"rbac.authorization.k8s.io_v1_clusterrolebinding_gatekeeper-manager-rolebinding.yaml": {configGatekeeperRbacAuthorizationK8sIo_v1_clusterrolebinding_gatekeeperManagerRolebindingYaml, map[string]*bintree{}},
 			"rbac.authorization.k8s.io_v1_role_gatekeeper-manager-role.yaml":                      {configGatekeeperRbacAuthorizationK8sIo_v1_role_gatekeeperManagerRoleYaml, map[string]*bintree{}},
 			"rbac.authorization.k8s.io_v1_rolebinding_gatekeeper-manager-rolebinding.yaml":        {configGatekeeperRbacAuthorizationK8sIo_v1_rolebinding_gatekeeperManagerRolebindingYaml, map[string]*bintree{}},
+			"v1_namespace_gatekeeper-system.yaml":                                                 {configGatekeeperV1_namespace_gatekeeperSystemYaml, map[string]*bintree{}},
 			"v1_secret_gatekeeper-webhook-server-cert.yaml":                                       {configGatekeeperV1_secret_gatekeeperWebhookServerCertYaml, map[string]*bintree{}},
 			"v1_service_gatekeeper-webhook-service.yaml":                                          {configGatekeeperV1_service_gatekeeperWebhookServiceYaml, map[string]*bintree{}},
 			"v1_serviceaccount_gatekeeper-admin.yaml":                                             {configGatekeeperV1_serviceaccount_gatekeeperAdminYaml, map[string]*bintree{}},

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -1,0 +1,52 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	DefaultGatekeeperNamespace          = "gatekeeper-system"
+	DefaultOpenShiftGatekeeperNamespace = "openshift-gatekeeper-system"
+)
+
+// GetOperatorNamespace returns the namespace the operator is running in from
+// the associated service account secret.
+func GetOperatorNamespace() (string, error) {
+	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("namespace not found for current environment")
+		}
+		return "", err
+	}
+	ns := strings.TrimSpace(string(nsBytes))
+	return ns, nil
+}
+
+// GetPlatformNamespace returns the namespace for the designated platform.
+func GetPlatformNamespace(platformName string) string {
+	switch PlatformType(platformName) {
+	case OpenShift:
+		return DefaultOpenShiftGatekeeperNamespace
+	default:
+		return DefaultGatekeeperNamespace
+	}
+}

--- a/pkg/util/platform.go
+++ b/pkg/util/platform.go
@@ -1,0 +1,22 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+type PlatformType string
+
+const (
+	OpenShift  PlatformType = "OpenShift"
+	Kubernetes PlatformType = "Kubernetes"
+)

--- a/pkg/util/platform.go
+++ b/pkg/util/platform.go
@@ -20,3 +20,7 @@ const (
 	OpenShift  PlatformType = "OpenShift"
 	Kubernetes PlatformType = "Kubernetes"
 )
+
+func IsOpenShift(platformName PlatformType) bool {
+	return platformName == OpenShift
+}


### PR DESCRIPTION
This adds the ability to use a default canonical namespace to install Gatekeeper when running on OpenShift, or default to using the same namespace as the operator on vanilla Kubernetes. As a result, the `WATCH_NAMESPACE` feature has been completely removed as this cluster scoped operator does not currently have a need for it.

Closes #93 