### PR TITLE
Verify release manifest in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         # so pass an unset REPO variable to use the default within the
         # Makefile.
         unset REPO
-        make release
+        make release IMG_TAG=${RELEASE_VERSION}
         git diff --exit-code ./deploy/gatekeeper-operator.yaml
 
     - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,16 @@ jobs:
         echo "RELEASE_BUNDLE_INDEX_IMG=${RELEASE_IMG}-bundle-index" >> ${GITHUB_ENV}
 
     - uses: actions/checkout@v2
+
+    - name: Verify release manifest
+      run: |
+        # GitHub Actions obfuscates values of secrets e.g. REPO='quay.io/***',
+        # so pass an unset REPO variable to use the default within the
+        # Makefile.
+        unset REPO
+        make release
+        git diff --exit-code ./deploy/gatekeeper-operator.yaml
+
     - uses: docker/setup-qemu-action@v1
     - uses: docker/setup-buildx-action@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -325,5 +325,4 @@ release: manifests kustomize
 	cd config/default && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 	cd $(RBAC_DIR) && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	{ $(KUSTOMIZE) build config/default ; echo "---" ; $(KUSTOMIZE) build $(RBAC_DIR) ; } > deploy/gatekeeper-operator.yaml
-
+	{ $(KUSTOMIZE) build config/default ; echo "---" ; $(KUSTOMIZE) build $(RBAC_DIR) ; } > ./deploy/gatekeeper-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+IMG_TAG ?= latest
 # Image URL to use all building/pushing image targets
-IMG ?= $(REPO)/gatekeeper-operator:latest
+IMG ?= $(REPO)/gatekeeper-operator:$(IMG_TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1beta1"
 

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -678,7 +678,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/gatekeeper/gatekeeper-operator:latest
+        image: quay.io/gatekeeper/gatekeeper-operator:v0.0.1-rc.0
         imagePullPolicy: Always
         name: manager
         resources:

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -678,7 +678,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/gatekeeper/gatekeeper-operator:v0.0.1-rc.0
+        image: quay.io/gatekeeper/gatekeeper-operator:v0.0.1-rc.1
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
This also updates the image tag in the release manifest from `latest` to use the specific release version image tag.