### PR TITLE
Use operator version from Makefile

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -26,7 +26,9 @@ jobs:
         make deploy-olm
 
     - name: Build and Push Test Container Image and Bundle/Bundle Index Images
-      run: make build-and-push-bundle-images IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA REPO=localhost:5000 VERSION=$GITHUB_SHA OPERATOR_VERSION=0.0.1-rc.0
+      run: |
+        OPERATOR_VERSION=$(awk '/^VERSION/ {print $3}' Makefile)
+        make build-and-push-bundle-images IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA REPO=localhost:5000 VERSION=$GITHUB_SHA OPERATOR_VERSION=${OPERATOR_VERSION}
 
     - name: Deploy resources on KIND cluster to install Gatekeeper
       run: |


### PR DESCRIPTION
When invoking make bundle, the operator version passed in needs to match
the version in the CSV bundle. Therefore, it's best not to rely on a
hard-coded version as it will need to be updated each time a new release
of the operator is made because the CSV version will have been updated.
Instead of hard-coding the version, this change will use the version
that is stored in the Makefile, which is the canonical source for the
operator version and so will be kept updated for every release.