### PR TITLE
Fetch all tags and branches in GitHub Actions workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
     - uses: actions/setup-go@v2
       id: go
       with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,6 +25,8 @@ jobs:
         echo "WORKFLOW_BUNDLE_INDEX_IMG=${WORKFLOW_IMG}-bundle-index" >> ${GITHUB_ENV}
 
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
     - uses: docker/setup-qemu-action@v1
     - uses: docker/setup-buildx-action@v1
       with:

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -15,6 +15,8 @@ jobs:
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
     - uses: actions/setup-go@v2
       id: go
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
         echo "RELEASE_BUNDLE_INDEX_IMG=${RELEASE_IMG}-bundle-index" >> ${GITHUB_ENV}
 
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Verify release manifest
       run: |

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ GOFLAGS = -mod=vendor
 
 # Set version variables for LDFLAGS
 GIT_VERSION ?= $(shell git describe --always --dirty)
-GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 GIT_TREESTATE = "clean"


### PR DESCRIPTION
GitHub Actions workflows should fetch all tags and branches so that the `git describe` that's used to generate the operator version that's logged at startup accurately reflects the tag/branch it's based off.
