### PR TITLE
Add support for Gatekeeper mutation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+defaults:
+  run:
+    shell: bash
+    working-directory: gatekeeper-operator
+
 jobs:
   main:
     runs-on: ubuntu-18.04
@@ -14,9 +19,12 @@ jobs:
         go: [ '1.15' ]
     name: Go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Gatekeeper Operator
+      uses: actions/checkout@v2
       with:
+        path: gatekeeper-operator
         fetch-depth: 0 # Fetch all history for all tags and branches
+
     - uses: actions/setup-go@v2
       id: go
       with:
@@ -35,9 +43,35 @@ jobs:
         make manifests
         git diff --exit-code
 
+    - name: Set Up Environment Variables
+      run: |
+        GATEKEEPER_VERSION=$(awk '/^GATEKEEPER_VERSION/ {print $3}' Makefile)
+        echo "GATEKEEPER_VERSION=${GATEKEEPER_VERSION}" >> ${GITHUB_ENV}
+
+    # This step is necessary to use a local clone of the Gatekeeper repo.
+    # Otherwise kustomize bulid fails using the go-getter URL format as result
+    # of https://github.com/open-policy-agent/gatekeeper/issues/1112. Also see
+    # https://github.com/kubernetes-sigs/kustomize/issues/3515 for a feature
+    # request.
+    - name: Checkout Gatekeeper to verify imported manifests
+      uses: actions/checkout@v2
+      with:
+        repository: open-policy-agent/gatekeeper
+        ref: ${{ env.GATEKEEPER_VERSION }}
+        path: gatekeeper
+        fetch-depth: 0 # Fetch all history for all tags and branches
+
+    # Build Gatekeeper manifests with some workarounds due to issue described
+    # above.
+    - name: Prepare Gatekeeper manifests for importing
+      working-directory: gatekeeper
+      run: |
+        make patch-image IMG=openpolicyagent/gatekeeper:${GATEKEEPER_VERSION}
+        sed -i '/--emit-\(audit\|admission\)-events/d' config/overlays/dev/manager_image_patch.yaml
+
     - name: Verify imported manifests
       run: |
-        make import-manifests
+        make import-manifests IMPORT_MANIFESTS_PATH=${GITHUB_WORKSPACE}/gatekeeper
         git diff --exit-code
 
     - name: Verify bindata

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,20 @@ deploy: manifests kustomize
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:rbac:dir=config/rbac/base
 
+# Path used to import Gatekeeper manifests. For example, this could be a local
+# file system directory if kustomize has errors using the GitHub URL. See
+# https://github.com/kubernetes-sigs/kustomize/issues/3515 for details.
+IMPORT_MANIFESTS_PATH ?= https://github.com/open-policy-agent/gatekeeper
+
 # Import Gatekeeper manifests
 .PHONY: import-manifests
 import-manifests: kustomize
-	$(KUSTOMIZE) build github.com/open-policy-agent/gatekeeper/config/default/?ref=$(GATEKEEPER_VERSION) -o $(GATEKEEPER_MANIFEST_DIR)
+	if [[ $(IMPORT_MANIFESTS_PATH) =~ https://* ]]; then \
+		$(KUSTOMIZE) build $(IMPORT_MANIFESTS_PATH)/config/overlays/mutation_webhook/?ref=$(GATEKEEPER_VERSION) -o $(GATEKEEPER_MANIFEST_DIR); \
+	else \
+		$(KUSTOMIZE) build $(IMPORT_MANIFESTS_PATH)/config/overlays/mutation_webhook -o $(GATEKEEPER_MANIFEST_DIR); \
+		$(KUSTOMIZE) build --load_restrictor LoadRestrictionsNone $(IMPORT_MANIFESTS_PATH)/config/overlays/mutation -o $(GATEKEEPER_MANIFEST_DIR); \
+	fi
 
 # Run go fmt against code
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OS_NAME = $(shell uname -s)
 # Current Operator version
 VERSION ?= v0.0.1
 # Current Gatekeeper version
-GATEKEEPER_VERSION ?= v3.2.2
+GATEKEEPER_VERSION ?= v3.3.0
 # Default image repo
 REPO ?= quay.io/gatekeeper
 # Default bundle image tag

--- a/api/v1alpha1/gatekeeper_types.go
+++ b/api/v1alpha1/gatekeeper_types.go
@@ -37,6 +37,8 @@ type GatekeeperSpec struct {
 	// +optional
 	ValidatingWebhook *WebhookMode `json:"validatingWebhook,omitempty"`
 	// +optional
+	MutatingWebhook *WebhookMode `json:"mutatingWebhook,omitempty"`
+	// +optional
 	Webhook *WebhookConfig `json:"webhook,omitempty"`
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -159,6 +159,11 @@ func (in *GatekeeperSpec) DeepCopyInto(out *GatekeeperSpec) {
 		*out = new(WebhookMode)
 		**out = **in
 	}
+	if in.MutatingWebhook != nil {
+		in, out := &in.MutatingWebhook, &out.MutatingWebhook
+		*out = new(WebhookMode)
+		**out = **in
+	}
 	if in.Webhook != nil {
 		in, out := &in.Webhook, &out.Webhook
 		*out = new(WebhookConfig)

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -60,6 +60,18 @@ spec:
         - apiGroups:
           - admissionregistration.k8s.io
           resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
           - validatingwebhookconfigurations
           verbs:
           - create
@@ -103,6 +115,18 @@ spec:
           - update
         - apiGroups:
           - constraints.gatekeeper.sh
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - mutations.gatekeeper.sh
           resources:
           - '*'
           verbs:

--- a/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/bundle/manifests/operator.gatekeeper.sh_gatekeepers.yaml
@@ -440,6 +440,11 @@ spec:
                   description: PullPolicy describes a policy for if/when to pull a container image
                   type: string
               type: object
+            mutatingWebhook:
+              enum:
+              - Enabled
+              - Disabled
+              type: string
             nodeSelector:
               additionalProperties:
                 type: string

--- a/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
+++ b/config/crd/bases/operator.gatekeeper.sh_gatekeepers.yaml
@@ -684,6 +684,11 @@ spec:
                     container image
                   type: string
               type: object
+            mutatingWebhook:
+              enum:
+              - Enabled
+              - Disabled
+              type: string
             nodeSelector:
               additionalProperties:
                 type: string

--- a/config/gatekeeper/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml
+++ b/config/gatekeeper/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: gatekeeper-mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: gatekeeper-webhook-service
+      namespace: gatekeeper-system
+      path: /v1/mutate
+  failurePolicy: Ignore
+  name: mutation.gatekeeper.sh
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'

--- a/config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml
+++ b/config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assign.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: Assign
+    listKind: AssignList
+    plural: assign
+    singular: assign
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: Assign is the Schema for the assign API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignSpec defines the desired state of Assign
+          properties:
+            applyTo:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+              items:
+                description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                properties:
+                  groups:
+                    items:
+                      type: string
+                    type: array
+                  kinds:
+                    items:
+                      type: string
+                    type: array
+                  versions:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+              - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                ifIn:
+                  description: IfIn Only mutate if the current value is in the supplied list
+                  items:
+                    type: string
+                  type: array
+                ifNotIn:
+                  description: IfNotIn Only mutate if the current value is NOT in the supplied list
+                  items:
+                    type: string
+                  type: array
+                pathTests:
+                  items:
+                    description: "PathTests allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate"
+                    properties:
+                      condition:
+                        enum:
+                        - MustExist
+                        - MustNotExist
+                        type: string
+                      subPath:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: AssignStatus defines the observed state of Assign
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml
+++ b/config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assignmetadata.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: AssignMetadata
+    listKind: AssignMetadataList
+    plural: assignmetadata
+    singular: assignmetadata
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: AssignMetadata is the Schema for the assignmetadata API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignMetadataSpec defines the desired state of AssignMetadata
+          properties:
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+              - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          type: object
+        status:
+          description: AssignMetadataStatus defines the observed state of AssignMetadata
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: audit-controller
     gatekeeper.sh/operation: audit
     gatekeeper.sh/system: "yes"
   name: gatekeeper-audit
@@ -23,6 +23,7 @@ spec:
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --operation=audit
@@ -40,7 +41,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.2.2
+        image: openpolicyagent/gatekeeper:v3.3.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -70,6 +71,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
@@ -35,6 +35,7 @@ spec:
                   - webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
+      automountServiceAccountToken: true
       containers:
       - args:
         - --port=8443
@@ -53,7 +54,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.2.2
+        image: openpolicyagent/gatekeeper:v3.3.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -86,6 +87,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000

--- a/config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml
+++ b/config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml
@@ -133,3 +133,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - gatekeeper-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml
+++ b/config/gatekeeper/rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml
@@ -59,6 +59,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - mutations.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy
   resourceNames:
   - gatekeeper-admin

--- a/config/rbac/base/role.yaml
+++ b/config/rbac/base/role.yaml
@@ -17,6 +17,18 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
   - validatingwebhookconfigurations
   verbs:
   - create
@@ -60,6 +72,18 @@ rules:
   - update
 - apiGroups:
   - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mutations.gatekeeper.sh
   resources:
   - '*'
   verbs:

--- a/config/samples/gatekeeper_with_all_values.yaml
+++ b/config/samples/gatekeeper_with_all_values.yaml
@@ -27,7 +27,7 @@ spec:
     replicas: 2
     logLevel: ERROR
     emitAdmissionEvents: Enabled
-    failurePolicy: Fail
+    failurePolicy: Ignore
     resources:
       limits:
         cpu: 480m

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -42,27 +42,47 @@ import (
 	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
 )
 
-var (
+const (
 	defaultGatekeeperCrName        = "gatekeeper"
 	openshiftAssetsDir             = "openshift/"
 	NamespaceFile                  = "v1_namespace_gatekeeper-system.yaml"
-	RoleFile                       = "rbac.authorization.k8s.io_v1_role_gatekeeper-manager-role.yaml"
+	AssignCRDFile                  = "apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml"
+	AssignMetadataCRDFile          = "apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml"
 	AuditFile                      = "apps_v1_deployment_gatekeeper-audit.yaml"
 	WebhookFile                    = "apps_v1_deployment_gatekeeper-controller-manager.yaml"
+	ClusterRoleFile                = "rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml"
 	ClusterRoleBindingFile         = "rbac.authorization.k8s.io_v1_clusterrolebinding_gatekeeper-manager-rolebinding.yaml"
+	RoleFile                       = "rbac.authorization.k8s.io_v1_role_gatekeeper-manager-role.yaml"
 	RoleBindingFile                = "rbac.authorization.k8s.io_v1_rolebinding_gatekeeper-manager-rolebinding.yaml"
 	ServerCertFile                 = "v1_secret_gatekeeper-webhook-server-cert.yaml"
 	ValidatingWebhookConfiguration = "admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_gatekeeper-validating-webhook-configuration.yaml"
-	orderedStaticAssets            = []string{
+	MutatingWebhookConfiguration   = "admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml"
+	ValidationGatekeeperWebhook    = "validation.gatekeeper.sh"
+	managerContainer               = "manager"
+	LogLevelArg                    = "--log-level"
+	AuditIntervalArg               = "--audit-interval"
+	ConstraintViolationLimitArg    = "--constraint-violations-limit"
+	AuditFromCacheArg              = "--audit-from-cache"
+	AuditChunkSizeArg              = "--audit-chunk-size"
+	EmitAuditEventsArg             = "--emit-audit-events"
+	EmitAdmissionEventsArg         = "--emit-admission-events"
+	ExemptNamespaceArg             = "--exempt-namespace"
+	EnableMutationArg              = "--enable-mutation"
+)
+
+var (
+	orderedStaticAssets = []string{
 		NamespaceFile,
 		"apiextensions.k8s.io_v1beta1_customresourcedefinition_configs.config.gatekeeper.sh.yaml",
 		"apiextensions.k8s.io_v1beta1_customresourcedefinition_constrainttemplates.templates.gatekeeper.sh.yaml",
 		"apiextensions.k8s.io_v1beta1_customresourcedefinition_constrainttemplatepodstatuses.status.gatekeeper.sh.yaml",
 		"apiextensions.k8s.io_v1beta1_customresourcedefinition_constraintpodstatuses.status.gatekeeper.sh.yaml",
+		AssignCRDFile,
+		AssignMetadataCRDFile,
 		ServerCertFile,
 		"v1_serviceaccount_gatekeeper-admin.yaml",
 		"policy_v1beta1_podsecuritypolicy_gatekeeper-admin.yaml",
-		"rbac.authorization.k8s.io_v1_clusterrole_gatekeeper-manager-role.yaml",
+		ClusterRoleFile,
 		ClusterRoleBindingFile,
 		RoleFile,
 		RoleBindingFile,
@@ -70,20 +90,13 @@ var (
 		WebhookFile,
 		"v1_service_gatekeeper-webhook-service.yaml",
 		ValidatingWebhookConfiguration,
+		MutatingWebhookConfiguration,
 	}
-	ValidationGatekeeperWebhook = "validation.gatekeeper.sh"
-)
-
-const (
-	managerContainer            = "manager"
-	LogLevelArg                 = "--log-level"
-	AuditIntervalArg            = "--audit-interval"
-	ConstraintViolationLimitArg = "--constraint-violations-limit"
-	AuditFromCacheArg           = "--audit-from-cache"
-	AuditChunkSizeArg           = "--audit-chunk-size"
-	EmitAuditEventsArg          = "--emit-audit-events"
-	EmitAdmissionEventsArg      = "--emit-admission-events"
-	ExemptNamespaceArg          = "--exempt-namespace"
+	mutatingStaticAssets = []string{
+		AssignCRDFile,
+		AssignMetadataCRDFile,
+		MutatingWebhookConfiguration,
+	}
 )
 
 // GatekeeperReconciler reconciles a Gatekeeper object
@@ -203,16 +216,45 @@ func (r *GatekeeperReconciler) deployGatekeeperResources(gatekeeper *operatorv1a
 }
 
 func getStaticAssets(gatekeeper *operatorv1alpha1.Gatekeeper) []string {
-	if gatekeeper.Spec.ValidatingWebhook == nil || *gatekeeper.Spec.ValidatingWebhook == operatorv1alpha1.WebhookEnabled {
-		return orderedStaticAssets
-	}
+	validatingWebhookEnabled := gatekeeper.Spec.ValidatingWebhook == nil || *gatekeeper.Spec.ValidatingWebhook == operatorv1alpha1.WebhookEnabled
+	mutatingWebhookEnabled := mutatingWebhookEnabled(gatekeeper.Spec.MutatingWebhook)
+
+	// Copy over our set of ordered static assets so we maintain its
+	// immutability.
 	assets := make([]string, 0)
-	for _, a := range orderedStaticAssets {
-		if a != ValidatingWebhookConfiguration {
-			assets = append(assets, a)
+	assets = append(assets, orderedStaticAssets...)
+
+	if !validatingWebhookEnabled {
+		// Remove ValidatingWebhookConfiguration resource
+		assets = getSubsetOfAssets(assets, ValidatingWebhookConfiguration)
+	}
+
+	if !mutatingWebhookEnabled {
+		// Remove mutating resources
+		assets = getSubsetOfAssets(assets, mutatingStaticAssets...)
+	}
+
+	return assets
+}
+
+func mutatingWebhookEnabled(mode *operatorv1alpha1.WebhookMode) bool {
+	return mode != nil && *mode == operatorv1alpha1.WebhookEnabled
+}
+
+func getSubsetOfAssets(inputAssets []string, assetsToRemove ...string) []string {
+	outputAssets := make([]string, 0)
+	for _, i := range inputAssets {
+		addAsset := true
+		for _, j := range assetsToRemove {
+			if i == j {
+				addAsset = false
+			}
+		}
+		if addAsset {
+			outputAssets = append(outputAssets, i)
 		}
 	}
-	return assets
+	return outputAssets
 }
 
 func (r *GatekeeperReconciler) updateOrCreateResource(manifest *manifest.Manifest, gatekeeper *operatorv1alpha1.Gatekeeper) error {
@@ -289,8 +331,9 @@ func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, manifest
 	if err := setNamespace(manifest.Obj, asset, namespace); err != nil {
 		return err
 	}
+	switch asset {
 	// audit overrides
-	if asset == AuditFile {
+	case AuditFile:
 		if err := commonOverrides(manifest.Obj, gatekeeper.Spec); err != nil {
 			return err
 		}
@@ -302,9 +345,8 @@ func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, manifest
 				return err
 			}
 		}
-	}
 	// webhook overrides
-	if asset == WebhookFile {
+	case WebhookFile:
 		if err := commonOverrides(manifest.Obj, gatekeeper.Spec); err != nil {
 			return err
 		}
@@ -316,11 +358,21 @@ func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, manifest
 				return err
 			}
 		}
-	}
+		if mutatingWebhookEnabled(gatekeeper.Spec.MutatingWebhook) {
+			if err := setEnableMutation(manifest.Obj); err != nil {
+				return err
+			}
+		}
 	// ValidatingWebhookConfiguration overrides
-	if asset == ValidatingWebhookConfiguration {
+	case ValidatingWebhookConfiguration:
 		if err := validatingWebhookConfigurationOverrides(manifest.Obj, gatekeeper.Spec.Webhook); err != nil {
 			return err
+		}
+	case ClusterRoleFile:
+		if !mutatingWebhookEnabled(gatekeeper.Spec.MutatingWebhook) {
+			if err := removeMutatingRBACRules(manifest.Obj); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -393,6 +445,72 @@ func validatingWebhookConfigurationOverrides(obj *unstructured.Unstructured, web
 		}
 	}
 	return nil
+}
+
+type matchRuleFunc func(map[string]interface{}) (bool, error)
+
+var matchMutatingRBACRuleFns = []matchRuleFunc{
+	matchGatekeeperMutatingRBACRule,
+	matchMutatingWebhookConfigurationRBACRule,
+}
+
+func removeMutatingRBACRules(obj *unstructured.Unstructured) error {
+	for _, f := range matchMutatingRBACRuleFns {
+		if err := removeRBACRule(obj, f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeRBACRule(obj *unstructured.Unstructured, matchRuleFn matchRuleFunc) error {
+	rules, found, err := unstructured.NestedSlice(obj.Object, "rules")
+	if err != nil || !found {
+		return errors.Wrapf(err, "Failed to retrieve rules from clusterrole")
+	}
+
+	for i, rule := range rules {
+		r := rule.(map[string]interface{})
+		if found, err := matchRuleFn(r); err != nil {
+			return err
+		} else if found {
+			rules = append(rules[:i], rules[i+1:]...)
+			break
+		}
+	}
+
+	if err := unstructured.SetNestedSlice(obj.Object, rules, "rules"); err != nil {
+		return errors.Wrapf(err, "Failed to set rules in clusterrole")
+	}
+
+	return nil
+}
+
+func matchGatekeeperMutatingRBACRule(rule map[string]interface{}) (bool, error) {
+	apiGroups, found, err := unstructured.NestedStringSlice(rule, "apiGroups")
+	if !found || err != nil {
+		return false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
+	}
+	if apiGroups[0] == "mutations.gatekeeper.sh" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func matchMutatingWebhookConfigurationRBACRule(rule map[string]interface{}) (bool, error) {
+	apiGroups, found, err := unstructured.NestedStringSlice(rule, "apiGroups")
+	if !found || err != nil {
+		return false, errors.Wrapf(err, "Failed to retrieve apiGroups from rule")
+	}
+	resources, found, err := unstructured.NestedStringSlice(rule, "resources")
+	if !found || err != nil {
+		return false, errors.Wrapf(err, "Failed to retrieve resources from rule")
+	}
+	if apiGroups[0] == "admissionregistration.k8s.io" &&
+		resources[0] == "mutatingwebhookconfigurations" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func containerOverrides(obj *unstructured.Unstructured, spec operatorv1alpha1.GatekeeperSpec) error {
@@ -472,6 +590,10 @@ func setEmitEvents(obj *unstructured.Unstructured, argName string, emitEvents *o
 		return setContainerArg(obj, managerContainer, argName, emitArgValue)
 	}
 	return nil
+}
+
+func setEnableMutation(obj *unstructured.Unstructured) error {
+	return setContainerArg(obj, managerContainer, EnableMutationArg, "true")
 }
 
 func setWebhookConfigurationWithFn(obj *unstructured.Unstructured, webhookName string, webhookFn func(map[string]interface{}) error) error {

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -110,6 +110,7 @@ type GatekeeperReconciler struct {
 // +kubebuilder:rbac:groups=config.gatekeeper.sh,resources=configs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.gatekeeper.sh,resources=configs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=constraints.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mutations.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=create;delete;update;use
 // +kubebuilder:rbac:groups=status.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=templates.gatekeeper.sh,resources=constrainttemplates,verbs=get;list;watch;create;update;patch;delete
@@ -117,6 +118,7 @@ type GatekeeperReconciler struct {
 // +kubebuilder:rbac:groups=templates.gatekeeper.sh,resources=constrainttemplates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 
 // Namespace Scoped
 // +kubebuilder:rbac:groups=core,namespace="system",resources=secrets;serviceaccounts;services,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -1,6 +1,9 @@
 // Code generated for package bindata by go-bindata DO NOT EDIT. (@generated)
 // sources:
+// config/gatekeeper/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml
 // config/gatekeeper/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_gatekeeper-validating-webhook-configuration.yaml
+// config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml
+// config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml
 // config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_configs.config.gatekeeper.sh.yaml
 // config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_constraintpodstatuses.status.gatekeeper.sh.yaml
 // config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_constrainttemplatepodstatuses.status.gatekeeper.sh.yaml
@@ -70,6 +73,47 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
+var _configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: gatekeeper-mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: gatekeeper-webhook-service
+      namespace: gatekeeper-system
+      path: /v1/mutate
+  failurePolicy: Ignore
+  name: mutation.gatekeeper.sh
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+`)
+
+func configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYamlBytes() ([]byte, error) {
+	return _configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYaml, nil
+}
+
+func configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYaml() (*asset, error) {
+	bytes, err := configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/gatekeeper/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _configGatekeeperAdmissionregistrationK8sIo_v1beta1_validatingwebhookconfiguration_gatekeeperValidatingWebhookConfigurationYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -134,6 +178,378 @@ func configGatekeeperAdmissionregistrationK8sIo_v1beta1_validatingwebhookconfigu
 	}
 
 	info := bindataFileInfo{name: "config/gatekeeper/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_gatekeeper-validating-webhook-configuration.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYaml = []byte(`apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assign.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: Assign
+    listKind: AssignList
+    plural: assign
+    singular: assign
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: Assign is the Schema for the assign API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignSpec defines the desired state of Assign
+          properties:
+            applyTo:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+              items:
+                description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                properties:
+                  groups:
+                    items:
+                      type: string
+                    type: array
+                  kinds:
+                    items:
+                      type: string
+                    type: array
+                  versions:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+              - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                ifIn:
+                  description: IfIn Only mutate if the current value is in the supplied list
+                  items:
+                    type: string
+                  type: array
+                ifNotIn:
+                  description: IfNotIn Only mutate if the current value is NOT in the supplied list
+                  items:
+                    type: string
+                  type: array
+                pathTests:
+                  items:
+                    description: "PathTests allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All ` + "`" + `subPath` + "`" + ` entries must be a prefix of ` + "`" + `location` + "`" + `. Any glob characters will take on the same value as was used to expand the matching glob in ` + "`" + `location` + "`" + `. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate"
+                    properties:
+                      condition:
+                        enum:
+                        - MustExist
+                        - MustNotExist
+                        type: string
+                      subPath:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: AssignStatus defines the observed state of Assign
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+`)
+
+func configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYamlBytes() ([]byte, error) {
+	return _configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYaml, nil
+}
+
+func configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYaml() (*asset, error) {
+	bytes, err := configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYaml = []byte(`apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: assignmetadata.mutations.gatekeeper.sh
+spec:
+  group: mutations.gatekeeper.sh
+  names:
+    kind: AssignMetadata
+    listKind: AssignMetadataList
+    plural: assignmetadata
+    singular: assignmetadata
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      description: AssignMetadata is the Schema for the assignmetadata API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AssignMetadataSpec defines the desired state of AssignMetadata
+          properties:
+            location:
+              type: string
+            match:
+              properties:
+                excludedNamespaces:
+                  items:
+                    type: string
+                  type: array
+                kinds:
+                  items:
+                    description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                    properties:
+                      apiGroups:
+                        description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                labelSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                namespaces:
+                  items:
+                    type: string
+                  type: array
+                scope:
+                  description: ResourceScope is an enum defining the different scopes available to a custom resource
+                  type: string
+              required:
+              - scope
+              type: object
+            parameters:
+              properties:
+                assign:
+                  description: Assign.value holds the value to be assigned
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+          type: object
+        status:
+          description: AssignMetadataStatus defines the observed state of AssignMetadata
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+`)
+
+func configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYamlBytes() ([]byte, error) {
+	return _configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYaml, nil
+}
+
+func configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYaml() (*asset, error) {
+	bytes, err := configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1024,6 +1440,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - gatekeeper-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 `)
 
 func configGatekeeperRbacAuthorizationK8sIo_v1_clusterrole_gatekeeperManagerRoleYamlBytes() ([]byte, error) {
@@ -1306,7 +1736,10 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
+	"config/gatekeeper/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml":     configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYaml,
 	"config/gatekeeper/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_gatekeeper-validating-webhook-configuration.yaml": configGatekeeperAdmissionregistrationK8sIo_v1beta1_validatingwebhookconfiguration_gatekeeperValidatingWebhookConfigurationYaml,
+	"config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml":                            configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYaml,
+	"config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml":                    configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYaml,
 	"config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_configs.config.gatekeeper.sh.yaml":                              configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_configsConfigGatekeeperShYaml,
 	"config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_constraintpodstatuses.status.gatekeeper.sh.yaml":                configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_constraintpodstatusesStatusGatekeeperShYaml,
 	"config/gatekeeper/apiextensions.k8s.io_v1beta1_customresourcedefinition_constrainttemplatepodstatuses.status.gatekeeper.sh.yaml":        configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_constrainttemplatepodstatusesStatusGatekeeperShYaml,
@@ -1368,7 +1801,10 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": {nil, map[string]*bintree{
 		"gatekeeper": {nil, map[string]*bintree{
+			"admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_gatekeeper-mutating-webhook-configuration.yaml":     {configGatekeeperAdmissionregistrationK8sIo_v1beta1_mutatingwebhookconfiguration_gatekeeperMutatingWebhookConfigurationYaml, map[string]*bintree{}},
 			"admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_gatekeeper-validating-webhook-configuration.yaml": {configGatekeeperAdmissionregistrationK8sIo_v1beta1_validatingwebhookconfiguration_gatekeeperValidatingWebhookConfigurationYaml, map[string]*bintree{}},
+			"apiextensions.k8s.io_v1beta1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml":                            {configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignMutationsGatekeeperShYaml, map[string]*bintree{}},
+			"apiextensions.k8s.io_v1beta1_customresourcedefinition_assignmetadata.mutations.gatekeeper.sh.yaml":                    {configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_assignmetadataMutationsGatekeeperShYaml, map[string]*bintree{}},
 			"apiextensions.k8s.io_v1beta1_customresourcedefinition_configs.config.gatekeeper.sh.yaml":                              {configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_configsConfigGatekeeperShYaml, map[string]*bintree{}},
 			"apiextensions.k8s.io_v1beta1_customresourcedefinition_constraintpodstatuses.status.gatekeeper.sh.yaml":                {configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_constraintpodstatusesStatusGatekeeperShYaml, map[string]*bintree{}},
 			"apiextensions.k8s.io_v1beta1_customresourcedefinition_constrainttemplatepodstatuses.status.gatekeeper.sh.yaml":        {configGatekeeperApiextensionsK8sIo_v1beta1_customresourcedefinition_constrainttemplatepodstatusesStatusGatekeeperShYaml, map[string]*bintree{}},

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -571,7 +571,7 @@ var _configGatekeeperApps_v1_deployment_gatekeeperAuditYaml = []byte(`apiVersion
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: audit-controller
     gatekeeper.sh/operation: audit
     gatekeeper.sh/system: "yes"
   name: gatekeeper-audit
@@ -592,6 +592,7 @@ spec:
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --operation=audit
@@ -609,7 +610,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.2.2
+        image: openpolicyagent/gatekeeper:v3.3.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -639,6 +640,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
@@ -700,6 +702,7 @@ spec:
                   - webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
+      automountServiceAccountToken: true
       containers:
       - args:
         - --port=8443
@@ -718,7 +721,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.2.2
+        image: openpolicyagent/gatekeeper:v3.3.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -751,6 +754,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
@@ -935,6 +939,18 @@ rules:
   - update
 - apiGroups:
   - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - mutations.gatekeeper.sh
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
This upgrades the Gatekeeper version to v3.3.0 and adds support for enabling Gatekeeper mutation.

This does not include the support for being able to set the `failurePolicy` or `namespaceSelector` fields in the `MutatingWebhookConfiguration` as is done in the `ValidatingWebhookConfiguration`. I plan to do this in a follow-up PR assuming it's also desired.

Also, I would like to add the Gatekeeper mutating bats e2e tests in a follow-up PR.

@mmirecki @fedepaol 