### PR TITLE
Retain MutationgWebhookConfiguration CABundle

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
               "replicas": 1
             },
             "image": {
-              "image": "docker.io/openpolicyagent/gatekeeper:v3.2.2"
+              "image": "docker.io/openpolicyagent/gatekeeper:v3.3.0"
             },
             "validatingWebhook": "Enabled",
             "webhook": {

--- a/config/samples/operator_v1alpha1_gatekeeper.yaml
+++ b/config/samples/operator_v1alpha1_gatekeeper.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Add fields here
   image:
-    image: docker.io/openpolicyagent/gatekeeper:v3.2.2
+    image: docker.io/openpolicyagent/gatekeeper:v3.3.0
   audit:
     replicas: 1
     logLevel: INFO

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -781,7 +781,7 @@ func setNamespace(obj *unstructured.Unstructured, asset, namespace string) error
 }
 
 func setClientConfigNamespace(obj *unstructured.Unstructured, asset, namespace string) error {
-	if asset != ValidatingWebhookConfiguration {
+	if asset != ValidatingWebhookConfiguration && asset != MutatingWebhookConfiguration {
 		return nil
 	}
 	webhooks, found, err := unstructured.NestedSlice(obj.Object, "webhooks")

--- a/controllers/merge/merge_test.go
+++ b/controllers/merge/merge_test.go
@@ -1,0 +1,90 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package merge
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
+)
+
+func TestRetainClusterObjectFields(t *testing.T) {
+	g := NewWithT(t)
+
+	testCases := map[string]struct {
+		desiredCABundle string
+		clusterCABundle string
+	}{
+		"cluster CABundle is empty": {
+			desiredCABundle: "ZGVzaXJlZCBkZWZhdWx0IHZhbHVlCg==",
+			clusterCABundle: "Cg==",
+		},
+		"cluster CABundle is set": {
+			desiredCABundle: "Cg==",
+			clusterCABundle: "Y2x1c3RlciBDQUJ1bmRsZSBpcyBzZXQK",
+		},
+	}
+
+	webhookConfigKinds := []string{
+		util.ValidatingWebhookConfigurationKind,
+		util.MutatingWebhookConfigurationKind,
+	}
+	for testName, testCase := range testCases {
+		for _, kind := range webhookConfigKinds {
+			t.Run(testName, func(t *testing.T) {
+				desiredObj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": kind,
+						"webhooks": []interface{}{
+							map[string]interface{}{
+								"clientConfig": map[string]interface{}{
+									"caBundle": testCase.desiredCABundle,
+								},
+							},
+						},
+					},
+				}
+				clusterObj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": kind,
+						"webhooks": []interface{}{
+							map[string]interface{}{
+								"clientConfig": map[string]interface{}{
+									"caBundle": testCase.clusterCABundle,
+								},
+							},
+						},
+					},
+				}
+
+				err := RetainClusterObjectFields(desiredObj, clusterObj)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				desiredWebhooks, found, err := unstructured.NestedSlice(desiredObj.Object, "webhooks")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(desiredWebhooks).ToNot(BeNil())
+
+				desiredCABundle, found, err := unstructured.NestedString(desiredWebhooks[0].(map[string]interface{}), "clientConfig", "caBundle")
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(desiredCABundle).To(Equal(testCase.clusterCABundle))
+			})
+		}
+	}
+}

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,21 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	ServiceKind                        = "Service"
+	ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
+	MutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"
+)

--- a/test/gatekeeper_controller_test.go
+++ b/test/gatekeeper_controller_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Gatekeeper", func() {
 			By("Checking default failure policy", func() {
 				webhookConfiguration := &unstructured.Unstructured{}
 				webhookConfiguration.SetAPIVersion(admregv1.SchemeGroupVersion.String())
-				webhookConfiguration.SetKind("ValidatingWebhookConfiguration")
+				webhookConfiguration.SetKind(util.ValidatingWebhookConfigurationKind)
 				Eventually(func() error {
 					return K8sClient.Get(ctx, validatingWebhookName, webhookConfiguration)
 				}, waitTimeout, pollInterval).ShouldNot(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = Describe("Gatekeeper", func() {
 			By("Checking expected failure policy", func() {
 				webhookConfiguration := &unstructured.Unstructured{}
 				webhookConfiguration.SetAPIVersion(admregv1.SchemeGroupVersion.String())
-				webhookConfiguration.SetKind("ValidatingWebhookConfiguration")
+				webhookConfiguration.SetKind(util.ValidatingWebhookConfigurationKind)
 				Eventually(func() error {
 					return K8sClient.Get(ctx, validatingWebhookName, webhookConfiguration)
 				}, waitTimeout, pollInterval).ShouldNot(HaveOccurred())
@@ -430,7 +430,7 @@ var _ = Describe("Gatekeeper", func() {
 			By("Checking expected failure policy", func() {
 				webhookConfiguration := &unstructured.Unstructured{}
 				webhookConfiguration.SetAPIVersion(admregv1.SchemeGroupVersion.String())
-				webhookConfiguration.SetKind("MutatingWebhookConfiguration")
+				webhookConfiguration.SetKind(util.MutatingWebhookConfigurationKind)
 				Eventually(func() error {
 					return K8sClient.Get(ctx, mutatingWebhookName, webhookConfiguration)
 				}, waitTimeout, pollInterval).ShouldNot(HaveOccurred())


### PR DESCRIPTION
- Upon updating the `MutatingWebhookConfiguration` as a result of a Gatekeeper CR reconcile, this adds retention for the `caBundle` that was in generated and injected by Gatekeeper at startup. It also adds unit tests to exercise this logic.
- Fixes namespace overrides for the mutating webhook service to support any custom namespace and adds unit tests for it.
- Update the operator sample CR and bundle (alm-examples annotation) to use Gatekeeper `v3.3.0`.

@mmirecki @fedepaol