### PR TITLE
Add namespaceSelector e2e tests

### DIFF
--- a/config/samples/gatekeeper_with_all_values.yaml
+++ b/config/samples/gatekeeper_with_all_values.yaml
@@ -28,6 +28,10 @@ spec:
     logLevel: ERROR
     emitAdmissionEvents: Enabled
     failurePolicy: Ignore
+    namespaceSelector:
+      matchExpressions:
+      - key: admission.gatekeeper.sh/enabled
+        operator: Exists
     resources:
       limits:
         cpu: 480m

--- a/test/gatekeeper_controller_test.go
+++ b/test/gatekeeper_controller_test.go
@@ -49,7 +49,7 @@ const (
 	// How long to try before giving up.
 	waitTimeout = 30 * time.Second
 	// Longer try before giving up.
-	longWaitTimeout = waitTimeout * 2
+	longWaitTimeout = waitTimeout * 4
 	// Gatekeeper name and namespace
 	gkName                      = "gatekeeper"
 	gkNamespace                 = "mygatekeeper"

--- a/test/gatekeeper_controller_test.go
+++ b/test/gatekeeper_controller_test.go
@@ -50,8 +50,9 @@ const (
 	// Longer try before giving up.
 	longWaitTimeout = waitTimeout * 2
 	// Gatekeeper name and namespace
-	gkName      = "gatekeeper"
-	gkNamespace = "mygatekeeper"
+	gkName                      = "gatekeeper"
+	gkNamespace                 = "mygatekeeper"
+	gatekeeperWithAllValuesFile = "gatekeeper_with_all_values.yaml"
 )
 
 var (
@@ -262,7 +263,7 @@ var _ = Describe("Gatekeeper", func() {
 		It("Contains the configured values", func() {
 			gatekeeper := &v1alpha1.Gatekeeper{}
 			gatekeeper.Namespace = gkNamespace
-			err := loadGatekeeperFromFile(gatekeeper, "gatekeeper_with_all_values.yaml")
+			err := loadGatekeeperFromFile(gatekeeper, gatekeeperWithAllValuesFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
 
@@ -399,7 +400,7 @@ var _ = Describe("Gatekeeper", func() {
 
 		It("Enables Gatekeeper Mutation", func() {
 			gatekeeper := emptyGatekeeper()
-			err := loadGatekeeperFromFile(gatekeeper, "gatekeeper_with_all_values.yaml")
+			err := loadGatekeeperFromFile(gatekeeper, gatekeeperWithAllValuesFile)
 			Expect(err).ToNot(HaveOccurred())
 			webhookMode := v1alpha1.WebhookEnabled
 			gatekeeper.Spec.MutatingWebhook = &webhookMode

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package util
 
 import (
 	admregv1 "k8s.io/api/admissionregistration/v1"


### PR DESCRIPTION
- Increases timeout for deletion of the Gatekeeper CR in-between tests.
- Refactors mutation enabled, `failurePolicy` and `namespaceSelector` e2e tests.