### PR TITLE
Delete Gatekeeper mutating/validating resources when mutation/validation is disabled

### DIFF
--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -43,8 +43,11 @@ func TestDeployWebhookConfigs(t *testing.T) {
 	// Test default (nil) webhook configurations
 	// ValidatingWebhookConfiguration nil
 	// MutatingWebhookConfiguration nil
-	g.Expect(getStaticAssets(gatekeeper)).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(getStaticAssets(gatekeeper)).NotTo(ContainElement(MutatingWebhookConfiguration))
+	deleteAssets, applyAssets := getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
 
 	webhookEnabled := operatorv1alpha1.WebhookEnabled
 	webhookDisabled := operatorv1alpha1.WebhookDisabled
@@ -53,29 +56,41 @@ func TestDeployWebhookConfigs(t *testing.T) {
 	// MutatingWebhookConfiguration enabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &webhookEnabled
-	g.Expect(getStaticAssets(gatekeeper)).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(getStaticAssets(gatekeeper)).To(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(deleteAssets).NotTo(ContainElements(mutatingStaticAssets))
 
 	// ValidatingWebhookConfiguration enabled
 	// MutatingWebhookConfiguration disabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &webhookDisabled
-	g.Expect(getStaticAssets(gatekeeper)).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(getStaticAssets(gatekeeper)).NotTo(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
 
 	// ValidatingWebhookConfiguration disabled
 	// MutatingWebhookConfiguration enabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &webhookEnabled
-	g.Expect(getStaticAssets(gatekeeper)).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(getStaticAssets(gatekeeper)).To(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(deleteAssets).NotTo(ContainElements(mutatingStaticAssets))
 
 	// ValidatingWebhookConfiguration disabled
 	// MutatingWebhookConfiguration disabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &webhookDisabled
-	g.Expect(getStaticAssets(gatekeeper)).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(getStaticAssets(gatekeeper)).NotTo(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
 }
 
 func TestGetSubsetOfAssets(t *testing.T) {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,6 +71,9 @@ var _ = BeforeSuite(func(done Done) {
 	K8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(K8sClient).ToNot(BeNil())
+
+	err = extv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	close(done)
 }, 60)


### PR DESCRIPTION
This adds support for deleting Gatekeeper mutating and validating resources when mutation and validation are disabled respectively. That is, when mutation or validation are enabled and then subsequently disabled, this now deletes the resources previously installed by those config options being enabled. This also adds unit tests and e2e tests to verify the expected behavior.

Fixes #131 

@fedepaol @mmirecki