### PR TITLE
Temporarily deploy webhooks with failurePolicy set to Ignore

### DIFF
--- a/config/samples/affinity_pod.yaml
+++ b/config/samples/affinity_pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: affinity-pod 
+  labels:
+    auditKey: auditValue
+spec:
+  containers:
+  - name: affinity-pod
+    image: docker.io/openpolicyagent/gatekeeper:v3.3.0
+    command: ["/bin/sh", "-c", "sleep INF"]
+  nodeSelector:
+    topology.kubernetes.io/zone: test
+    region: EMEA

--- a/config/samples/gatekeeper_with_all_values.yaml
+++ b/config/samples/gatekeeper_with_all_values.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Add fields here
   image:
-    image: docker.io/openpolicyagent/gatekeeper:v3.2.2
+    image: docker.io/openpolicyagent/gatekeeper:v3.3.0
     imagePullPolicy: Always
   audit:
     replicas: 1
@@ -17,11 +17,11 @@ spec:
     emitAuditEvents: Enabled
     resources:
       limits:
-        cpu: 500m
-        memory: 150Mi
+        cpu: 100m
+        memory: 20Mi
       requests:
-        cpu: 500m
-        memory: 130Mi
+        cpu: 100m
+        memory: 20Mi
   validatingWebhook: Enabled
   webhook:
     replicas: 2
@@ -34,11 +34,11 @@ spec:
         operator: Exists
     resources:
       limits:
-        cpu: 480m
-        memory: 140Mi
+        cpu: 100m
+        memory: 20Mi
       requests:
-        cpu: 400m
-        memory: 120Mi
+        cpu: 100m
+        memory: 20Mi
   nodeSelector:
     region: "EMEA"
   affinity:

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -212,7 +212,7 @@ func (r *GatekeeperReconciler) deployGatekeeperResources(gatekeeper *operatorv1a
 			return err, false
 		}
 	}
-	// Checking for deployment before deploying assets to avoid cert rotator erors
+	// Checking for deployment before deploying assets to avoid cert rotator errors
 	err, requeue := r.validateWebhookDeployment()
 	if err != nil {
 		return err, false

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -90,13 +90,15 @@ var (
 		AuditFile,
 		WebhookFile,
 		"v1_service_gatekeeper-webhook-service.yaml",
+	}
+	webhookStaticAssets = []string{
 		ValidatingWebhookConfiguration,
 		MutatingWebhookConfiguration,
 	}
-	mutatingStaticAssets = []string{
+
+	mutatingCRDs = []string{
 		AssignCRDFile,
 		AssignMetadataCRDFile,
-		MutatingWebhookConfiguration,
 	}
 )
 
@@ -169,8 +171,11 @@ func (r *GatekeeperReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		return ctrl.Result{}, err
 	}
 
-	if err = r.deployGatekeeperResources(gatekeeper); err != nil {
+	err, requeue := r.deployGatekeeperResources(gatekeeper)
+	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "Unable to deploy Gatekeeper resources")
+	} else if requeue {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -194,69 +199,137 @@ func (r *GatekeeperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *GatekeeperReconciler) deployGatekeeperResources(gatekeeper *operatorv1alpha1.Gatekeeper) error {
-	deleteAssets, applyAssets := getStaticAssets(gatekeeper)
+func (r *GatekeeperReconciler) deployGatekeeperResources(gatekeeper *operatorv1alpha1.Gatekeeper) (error, bool) {
+	deleteAssets, applyAssets, webhookAssets := getStaticAssets(gatekeeper)
 
 	for _, d := range deleteAssets {
 		obj, err := util.GetManifestObject(d)
 		if err != nil {
-			return nil
+			return err, false
 		}
 
 		if err = r.crudResource(obj, gatekeeper, delete); err != nil {
-			return err
+			return err, false
+		}
+	}
+	// Checking for deployment before deploying assets to avoid cert rotator erors
+	err, requeue := r.validateWebhookDeployment()
+	if err != nil {
+		return err, false
+	}
+	for _, asset := range applyAssets {
+		err := r.applyAsset(gatekeeper, asset, false)
+		if err != nil {
+			return err, false
 		}
 	}
 
-	for _, a := range applyAssets {
-		// Handle special cases in switch below.
-		switch {
-		case a == NamespaceFile && !r.isOpenShift():
-			// Ignore the namespace resource on Kubernetes as we default to use
-			// the same namespace as the operator, which by definition is
-			// already created as a result of executing this code.
-			continue
-		case a == RoleFile && r.isOpenShift():
-			a = openshiftAssetsDir + a
-		}
-
-		obj, err := util.GetManifestObject(a)
+	for _, asset := range webhookAssets {
+		err := r.applyAsset(gatekeeper, asset, requeue)
 		if err != nil {
-			return err
+			return err, false
 		}
-		if err = crOverrides(gatekeeper, a, obj, r.Namespace, r.isOpenShift()); err != nil {
-			return err
-		}
+	}
+	return nil, requeue
+}
 
-		if err = r.crudResource(obj, gatekeeper, apply); err != nil {
-			return err
-		}
+func (r *GatekeeperReconciler) applyAsset(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, controllerDeploymentPending bool) error {
+	// Handle special cases in switch below.
+	switch {
+	case asset == NamespaceFile && !r.isOpenShift():
+		// Ignore the namespace resource on Kubernetes as we default to use
+		// the same namespace as the operator, which by definition is
+		// already created as a result of executing this code.
+		return nil
+	case asset == RoleFile && r.isOpenShift():
+		asset = openshiftAssetsDir + asset
+	}
+
+	obj, err := util.GetManifestObject(asset)
+	if err != nil {
+		return err
+	}
+
+	if err = crOverrides(gatekeeper, asset, obj, r.Namespace, r.isOpenShift(), controllerDeploymentPending); err != nil {
+		return err
+	}
+
+	if err = r.crudResource(obj, gatekeeper, apply); err != nil {
+		return err
 	}
 	return nil
 }
 
-func getStaticAssets(gatekeeper *operatorv1alpha1.Gatekeeper) (deleteAssets, applyAssets []string) {
-	validatingWebhookEnabled := gatekeeper.Spec.ValidatingWebhook == nil || *gatekeeper.Spec.ValidatingWebhook == operatorv1alpha1.WebhookEnabled
-	mutatingWebhookEnabled := mutatingWebhookEnabled(gatekeeper.Spec.MutatingWebhook)
+func (r *GatekeeperReconciler) validateWebhookDeployment() (error, bool) {
+	r.Log.Info(fmt.Sprintf("Validating %s deployment status", WebhookFile))
 
+	ctx := context.Background()
+	obj, err := util.GetManifestObject(WebhookFile)
+	if err != nil {
+		return err, false
+	}
+	deployment := &unstructured.Unstructured{}
+	deployment.SetAPIVersion(obj.GetAPIVersion())
+	deployment.SetKind(obj.GetKind())
+	namespacedName := types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      obj.GetName(),
+	}
+
+	err = r.Get(ctx, namespacedName, deployment)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Log.Info("Deployment not found, requeuing ...")
+			return nil, true
+		}
+		return err, false
+	}
+	r.Log.Info("Deployment found, checking replicas ...")
+
+	replicas, ok, err := unstructured.NestedInt64(deployment.Object, "status", "replicas")
+	if err != nil {
+		return err, false
+	}
+
+	readyReplicas, ok, err := unstructured.NestedInt64(deployment.Object, "status", "readyReplicas")
+	if err != nil {
+		return err, false
+	}
+	if !ok {
+		return nil, true // State/readyReplicas might not yet be populated
+	}
+	if replicas == readyReplicas {
+		r.Log.Info("Deployment validation successful, all replicas ready", "replicas", replicas, "readyReplicas", readyReplicas)
+		return nil, false
+	}
+	r.Log.Info("Deployment replicas not ready, requeuing ...", "replicas", replicas, "readyReplicas", readyReplicas)
+	return nil, true
+}
+
+func getStaticAssets(gatekeeper *operatorv1alpha1.Gatekeeper) (deleteAssets, applyAssets, webhookAssets []string) {
+	validatingWebhookEnabled := gatekeeper.Spec.ValidatingWebhook == nil || *gatekeeper.Spec.ValidatingWebhook == operatorv1alpha1.WebhookEnabled
+	mutatingWebhookEnabled := gatekeeper.Spec.MutatingWebhook != nil && mutatingWebhookEnabled(gatekeeper.Spec.MutatingWebhook)
 	deleteAssets = make([]string, 0)
 	applyAssets = make([]string, 0)
+	webhookAssets = make([]string, 0)
 	// Copy over our set of ordered static assets so we maintain its
 	// immutability.
 	applyAssets = append(applyAssets, orderedStaticAssets...)
+	webhookAssets = append(webhookAssets, webhookStaticAssets...)
 
 	if !validatingWebhookEnabled {
 		// Remove ValidatingWebhookConfiguration resource
 		deleteAssets = append(deleteAssets, ValidatingWebhookConfiguration)
-		applyAssets = getSubsetOfAssets(applyAssets, ValidatingWebhookConfiguration)
+		webhookAssets = getSubsetOfAssets(webhookAssets, ValidatingWebhookConfiguration)
 	}
 
 	if !mutatingWebhookEnabled {
 		// Remove mutating resources
-		deleteAssets = append(deleteAssets, mutatingStaticAssets...)
-		applyAssets = getSubsetOfAssets(applyAssets, mutatingStaticAssets...)
+		deleteAssets = append(deleteAssets, mutatingCRDs...)
+		deleteAssets = append(deleteAssets, MutatingWebhookConfiguration)
+		applyAssets = getSubsetOfAssets(applyAssets, mutatingCRDs...)
+		webhookAssets = getSubsetOfAssets(webhookAssets, MutatingWebhookConfiguration)
 	}
-
 	return
 }
 
@@ -352,7 +425,7 @@ var commonContainerOverridesFn = []func(map[string]interface{}, operatorv1alpha1
 }
 
 // crOverrides
-func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, obj *unstructured.Unstructured, namespace string, isOpenshift bool) error {
+func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, obj *unstructured.Unstructured, namespace string, isOpenshift bool, controllerDeploymentPending bool) error {
 	if asset == NamespaceFile {
 		obj.SetName(namespace)
 		return nil
@@ -395,15 +468,15 @@ func crOverrides(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, obj *uns
 		}
 	// ValidatingWebhookConfiguration overrides
 	case ValidatingWebhookConfiguration:
-		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, ValidationGatekeeperWebhook, true); err != nil {
+		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, ValidationGatekeeperWebhook, true, controllerDeploymentPending); err != nil {
 			return err
 		}
-		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, CheckIgnoreLabelGatekeeperWebhook, false); err != nil {
+		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, CheckIgnoreLabelGatekeeperWebhook, false, controllerDeploymentPending); err != nil {
 			return err
 		}
 	// MutatingWebhookConfiguration overrides
 	case MutatingWebhookConfiguration:
-		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, MutationGatekeeperWebhook, true); err != nil {
+		if err := webhookConfigurationOverrides(obj, gatekeeper.Spec.Webhook, MutationGatekeeperWebhook, true, controllerDeploymentPending); err != nil {
 			return err
 		}
 	// ClusterRole overrides
@@ -474,10 +547,15 @@ func webhookOverrides(obj *unstructured.Unstructured, webhook *operatorv1alpha1.
 	return nil
 }
 
-func webhookConfigurationOverrides(obj *unstructured.Unstructured, webhook *operatorv1alpha1.WebhookConfig, webhookName string, updateFailurePolicy bool) error {
+func webhookConfigurationOverrides(obj *unstructured.Unstructured, webhook *operatorv1alpha1.WebhookConfig, webhookName string, updateFailurePolicy bool, controllerDeploymentPending bool) error {
 	if webhook != nil {
-		if updateFailurePolicy {
-			if err := setFailurePolicy(obj, webhook.FailurePolicy, webhookName); err != nil {
+		if updateFailurePolicy || controllerDeploymentPending {
+			failurePolicy := webhook.FailurePolicy
+			if controllerDeploymentPending {
+				ignore := admregv1.Ignore
+				failurePolicy = &ignore
+			}
+			if err := setFailurePolicy(obj, failurePolicy, webhookName); err != nil {
 				return err
 			}
 		}

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -42,11 +42,15 @@ func TestDeployWebhookConfigs(t *testing.T) {
 	// Test default (nil) webhook configurations
 	// ValidatingWebhookConfiguration nil
 	// MutatingWebhookConfiguration nil
-	deleteAssets, applyAssets := getStaticAssets(gatekeeper)
-	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets, webhookAssets := getStaticAssets(gatekeeper)
+	g.Expect(webhookAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(webhookAssets).NotTo(ContainElements(mutatingCRDs))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingCRDs))
+	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
 	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).To(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingCRDs))
 
 	webhookEnabled := operatorv1alpha1.WebhookEnabled
 	webhookDisabled := operatorv1alpha1.WebhookDisabled
@@ -55,48 +59,64 @@ func TestDeployWebhookConfigs(t *testing.T) {
 	// MutatingWebhookConfiguration enabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &webhookEnabled
-	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
-	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(applyAssets).To(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets, webhookAssets = getStaticAssets(gatekeeper)
+	g.Expect(applyAssets).To(ContainElements(mutatingCRDs))
+	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(webhookAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(webhookAssets).To(ContainElement(MutatingWebhookConfiguration))
 	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(deleteAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(deleteAssets).NotTo(ContainElements(mutatingCRDs))
 
 	// ValidatingWebhookConfiguration enabled
 	// MutatingWebhookConfiguration disabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &webhookDisabled
-	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
-	g.Expect(applyAssets).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	deleteAssets, applyAssets, webhookAssets = getStaticAssets(gatekeeper)
+	g.Expect(webhookAssets).To(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(webhookAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingCRDs))
 	g.Expect(deleteAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).To(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingCRDs))
 
 	// ValidatingWebhookConfiguration disabled
 	// MutatingWebhookConfiguration enabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &webhookEnabled
-	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	deleteAssets, applyAssets, webhookAssets = getStaticAssets(gatekeeper)
+	g.Expect(webhookAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(webhookAssets).To(ContainElement(MutatingWebhookConfiguration))
 	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(applyAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(applyAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(applyAssets).To(ContainElements(mutatingCRDs))
 	g.Expect(deleteAssets).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(deleteAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(deleteAssets).NotTo(ContainElements(mutatingCRDs))
 
 	// ValidatingWebhookConfiguration disabled
 	// MutatingWebhookConfiguration disabled
 	gatekeeper.Spec.ValidatingWebhook = &webhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &webhookDisabled
-	deleteAssets, applyAssets = getStaticAssets(gatekeeper)
+	deleteAssets, applyAssets, webhookAssets = getStaticAssets(gatekeeper)
+	g.Expect(webhookAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
+	g.Expect(webhookAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
 	g.Expect(applyAssets).NotTo(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(applyAssets).NotTo(ContainElements(mutatingStaticAssets))
+	g.Expect(applyAssets).NotTo(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(applyAssets).NotTo(ContainElements(mutatingCRDs))
 	g.Expect(deleteAssets).To(ContainElement(ValidatingWebhookConfiguration))
-	g.Expect(deleteAssets).To(ContainElements(mutatingStaticAssets))
+	g.Expect(deleteAssets).To(ContainElement(MutatingWebhookConfiguration))
+	g.Expect(deleteAssets).To(ContainElements(mutatingCRDs))
 }
 
 func TestGetSubsetOfAssets(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(getSubsetOfAssets(orderedStaticAssets)).To(Equal(orderedStaticAssets))
 	g.Expect(getSubsetOfAssets(orderedStaticAssets, orderedStaticAssets...)).To(HaveLen(0))
-	g.Expect(getSubsetOfAssets(orderedStaticAssets, mutatingStaticAssets...)).To(HaveLen(len(orderedStaticAssets) - len(mutatingStaticAssets)))
+	g.Expect(getSubsetOfAssets(orderedStaticAssets, mutatingCRDs...)).To(HaveLen(len(orderedStaticAssets) - len(mutatingCRDs)))
 }
 
 func TestCustomNamespace(t *testing.T) {
@@ -111,7 +131,7 @@ func TestCustomNamespace(t *testing.T) {
 	rolebindingObj, err := util.GetManifestObject(RoleBindingFile)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(rolebindingObj).ToNot(BeNil())
-	err = crOverrides(gatekeeper, RoleBindingFile, rolebindingObj, expectedNamespace, false)
+	err = crOverrides(gatekeeper, RoleBindingFile, rolebindingObj, expectedNamespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	subjects, found, err := unstructured.NestedSlice(rolebindingObj.Object, "subjects")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -129,7 +149,7 @@ func TestCustomNamespace(t *testing.T) {
 	webhookObj, err := util.GetManifestObject(WebhookFile)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(webhookObj).ToNot(BeNil())
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, expectedNamespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, expectedNamespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(getContainerArguments(g, managerContainer, webhookObj)).To(HaveKeyWithValue(ExemptNamespaceArg, expectedNamespace))
 
@@ -142,7 +162,7 @@ func TestCustomNamespace(t *testing.T) {
 		webhookConfig, err := util.GetManifestObject(webhookConfigFile)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(webhookConfig).ToNot(BeNil())
-		err = crOverrides(gatekeeper, webhookConfigFile, webhookConfig, expectedNamespace, false)
+		err = crOverrides(gatekeeper, webhookConfigFile, webhookConfig, expectedNamespace, false, false)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		assertWebhooksWithFn(g, webhookConfig, func(webhook map[string]interface{}) {
@@ -169,12 +189,12 @@ func TestReplicas(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	testObjReplicas(g, auditObj, test.DefaultDeployment.AuditReplicas)
 	// test nil audit replicas
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	testObjReplicas(g, auditObj, test.DefaultDeployment.AuditReplicas)
 	// test audit replicas override
 	gatekeeper.Spec.Audit = &operatorv1alpha1.AuditConfig{Replicas: &auditReplicaOverride}
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	testObjReplicas(g, auditObj, auditReplicaOverride)
 
@@ -184,12 +204,12 @@ func TestReplicas(t *testing.T) {
 	g.Expect(webhookObj).ToNot(BeNil())
 	testObjReplicas(g, webhookObj, test.DefaultDeployment.WebhookReplicas)
 	// test nil webhook replicas
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	testObjReplicas(g, webhookObj, test.DefaultDeployment.WebhookReplicas)
 	// test webhook replicas override
 	gatekeeper.Spec.Webhook = &operatorv1alpha1.WebhookConfig{Replicas: &webhookReplicaOverride}
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	testObjReplicas(g, webhookObj, webhookReplicaOverride)
 }
@@ -230,20 +250,20 @@ func TestAffinity(t *testing.T) {
 	assertWebhookAffinity(g, webhookObj, nil)
 
 	// test nil affinity
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertAuditAffinity(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertWebhookAffinity(g, webhookObj, nil)
 
 	// test affinity override
 	gatekeeper.Spec.Affinity = affinity
 
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertAuditAffinity(g, auditObj, affinity)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertWebhookAffinity(g, webhookObj, affinity)
 }
@@ -297,19 +317,19 @@ func TestNodeSelector(t *testing.T) {
 	assertNodeSelector(g, webhookObj, nil)
 
 	// test nil nodeSelector
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNodeSelector(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNodeSelector(g, webhookObj, nil)
 
 	// test nodeSelector override
 	gatekeeper.Spec.NodeSelector = nodeSelector
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNodeSelector(g, auditObj, nodeSelector)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNodeSelector(g, webhookObj, nodeSelector)
 }
@@ -347,19 +367,19 @@ func TestPodAnnotations(t *testing.T) {
 	assertPodAnnotations(g, webhookObj, nil)
 
 	// test nil podAnnotations
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertPodAnnotations(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertPodAnnotations(g, webhookObj, nil)
 
 	// test podAnnotations override
 	gatekeeper.Spec.PodAnnotations = podAnnotations
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertPodAnnotations(g, auditObj, podAnnotations)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertPodAnnotations(g, webhookObj, podAnnotations)
 }
@@ -405,19 +425,19 @@ func TestTolerations(t *testing.T) {
 	assertTolerations(g, webhookObj, nil)
 
 	// test nil tolerations
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertTolerations(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertTolerations(g, webhookObj, nil)
 
 	// test tolerations override
 	gatekeeper.Spec.Tolerations = tolerations
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertTolerations(g, auditObj, tolerations)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertTolerations(g, webhookObj, tolerations)
 }
@@ -475,21 +495,21 @@ func TestResources(t *testing.T) {
 	assertResources(g, webhookObj, nil)
 
 	// test nil resources
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertResources(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertResources(g, webhookObj, nil)
 
 	// test resources override
 	gatekeeper.Spec.Audit = audit
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertResources(g, auditObj, audit.Resources)
 
 	gatekeeper.Spec.Webhook = webhook
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertResources(g, webhookObj, webhook.Resources)
 }
@@ -542,19 +562,18 @@ func TestImage(t *testing.T) {
 	assertImage(g, webhookObj, nil)
 
 	// test nil image
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
-	g.Expect(err).ToNot(HaveOccurred())
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	assertImage(g, auditObj, nil)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertImage(g, webhookObj, nil)
 
 	// test image override
 	gatekeeper.Spec.Image = imageConfig
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertImage(g, auditObj, imageConfig)
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertImage(g, webhookObj, imageConfig)
 }
@@ -629,21 +648,34 @@ func TestFailurePolicy(t *testing.T) {
 	assertFailurePolicy(g, mutObj, MutatingWebhookConfiguration, nil)
 
 	// test nil failurePolicy
-	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false)
+	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertFailurePolicy(g, valObj, ValidationGatekeeperWebhook, nil)
-	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false)
+	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertFailurePolicy(g, mutObj, MutationGatekeeperWebhook, nil)
 
 	// test failurePolicy override
 	gatekeeper.Spec.Webhook = &webhook
-	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false)
+	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertFailurePolicy(g, valObj, ValidationGatekeeperWebhook, &failurePolicy)
-	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false)
+	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertFailurePolicy(g, mutObj, MutationGatekeeperWebhook, &failurePolicy)
+
+	// test controllerDeploymentPending override
+	failurePolicyIgnore := admregv1.Ignore
+	gatekeeper.Spec.Webhook = &webhook
+	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, true)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertFailurePolicy(g, valObj, ValidationGatekeeperWebhook, &failurePolicyIgnore)
+	err = crOverrides(gatekeeper, CheckIgnoreLabelGatekeeperWebhook, valObj, namespace, false, true)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertFailurePolicy(g, valObj, CheckIgnoreLabelGatekeeperWebhook, &failurePolicyIgnore)
+	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, true)
+	g.Expect(err).ToNot(HaveOccurred())
+	assertFailurePolicy(g, mutObj, MutationGatekeeperWebhook, &failurePolicyIgnore)
 }
 
 func assertFailurePolicy(g *WithT, obj *unstructured.Unstructured, webhookName string, expected *admregv1.FailurePolicyType) {
@@ -693,19 +725,19 @@ func TestNamespaceSelector(t *testing.T) {
 	assertNamespaceSelector(g, mutObj, MutationGatekeeperWebhook, nil)
 
 	// test nil namespaceSelector
-	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false)
+	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNamespaceSelector(g, valObj, ValidationGatekeeperWebhook, nil)
-	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false)
+	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNamespaceSelector(g, mutObj, MutationGatekeeperWebhook, nil)
 
 	// test namespaceSelector override
 	gatekeeper.Spec.Webhook = &webhook
-	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false)
+	err = crOverrides(gatekeeper, ValidatingWebhookConfiguration, valObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNamespaceSelector(g, valObj, ValidatingWebhookConfiguration, &namespaceSelector)
-	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false)
+	err = crOverrides(gatekeeper, MutatingWebhookConfiguration, mutObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	assertNamespaceSelector(g, mutObj, MutatingWebhookConfiguration, &namespaceSelector)
 }
@@ -768,12 +800,12 @@ func TestAuditInterval(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditIntervalArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditIntervalArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(AuditIntervalArg, "3600"))
 }
@@ -796,12 +828,12 @@ func TestAuditLogLevel(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(LogLevelArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(LogLevelArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(LogLevelArg, "DEBUG"))
 }
@@ -824,12 +856,12 @@ func TestAuditConstraintViolationLimit(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(ConstraintViolationLimitArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(ConstraintViolationLimitArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(ConstraintViolationLimitArg, "20"))
 }
@@ -852,12 +884,12 @@ func TestAuditChunkSize(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditChunkSizeArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditChunkSizeArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(AuditChunkSizeArg, "10"))
 }
@@ -880,12 +912,12 @@ func TestAuditFromCache(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditFromCacheArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditFromCacheArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(AuditFromCacheArg, "true"))
 }
@@ -908,12 +940,12 @@ func TestEmitAuditEvents(t *testing.T) {
 	g.Expect(auditObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(EmitAuditEventsArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(EmitAuditEventsArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(EmitAuditEventsArg, "true"))
 }
@@ -953,7 +985,7 @@ func TestAllAuditArgs(t *testing.T) {
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(EmitAuditEventsArg))
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditIntervalArg))
 	// test nil
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditChunkSizeArg))
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditFromCacheArg))
@@ -963,7 +995,7 @@ func TestAllAuditArgs(t *testing.T) {
 	expectObjContainerArgument(g, managerContainer, auditObj).NotTo(HaveKey(AuditIntervalArg))
 	// test override
 	gatekeeper.Spec.Audit = &auditOverride
-	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false)
+	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(AuditChunkSizeArg, "10"))
 	expectObjContainerArgument(g, managerContainer, auditObj).To(HaveKeyWithValue(AuditFromCacheArg, "true"))
@@ -991,12 +1023,12 @@ func TestEmitAdmissionEvents(t *testing.T) {
 	g.Expect(webhookObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EmitAdmissionEventsArg))
 	// test nil
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EmitAdmissionEventsArg))
 	// test override
 	gatekeeper.Spec.Webhook = &webhookOverride
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(EmitAdmissionEventsArg, "true"))
 }
@@ -1019,12 +1051,12 @@ func TestWebhookLogLevel(t *testing.T) {
 	g.Expect(webhookObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(LogLevelArg))
 	// test nil
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(LogLevelArg))
 	// test override
 	gatekeeper.Spec.Webhook = &webhookOverride
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(LogLevelArg, "DEBUG"))
 }
@@ -1044,18 +1076,18 @@ func TestMutationArg(t *testing.T) {
 	g.Expect(webhookObj).ToNot(BeNil())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	// test nil
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	// test disabled override
 	mutation := operatorv1alpha1.WebhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &mutation
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	// test enabled override
 	mutation = operatorv1alpha1.WebhookEnabled
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(EnableMutationArg, "true"))
 }
@@ -1082,14 +1114,14 @@ func TestAllWebhookArgs(t *testing.T) {
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(LogLevelArg))
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	// test nil
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EmitAdmissionEventsArg))
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(LogLevelArg))
 	expectObjContainerArgument(g, managerContainer, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	// test override without mutation
 	gatekeeper.Spec.Webhook = &webhookOverride
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(EmitAdmissionEventsArg, "true"))
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(LogLevelArg, "DEBUG"))
@@ -1097,7 +1129,7 @@ func TestAllWebhookArgs(t *testing.T) {
 	// test override with mutation
 	mutatingWebhook := operatorv1alpha1.WebhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &mutatingWebhook
-	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false)
+	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(EmitAdmissionEventsArg, "true"))
 	expectObjContainerArgument(g, managerContainer, webhookObj).To(HaveKeyWithValue(LogLevelArg, "DEBUG"))
@@ -1144,7 +1176,7 @@ func TestSetCertNamespace(t *testing.T) {
 	serverCertObj, err := util.GetManifestObject(ServerCertFile)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(serverCertObj).ToNot(BeNil())
-	err = crOverrides(gatekeeper, ServerCertFile, serverCertObj, namespace, false)
+	err = crOverrides(gatekeeper, ServerCertFile, serverCertObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(serverCertObj.GetNamespace()).To(Equal(namespace))
 }
@@ -1165,7 +1197,7 @@ func TestMutationRBACConfig(t *testing.T) {
 
 	// Test default RBAC config
 	obj = clusterRoleObj.DeepCopy()
-	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false)
+	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	rules, found, err := unstructured.NestedSlice(obj.Object, "rules")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1182,7 +1214,7 @@ func TestMutationRBACConfig(t *testing.T) {
 
 	// Test RBAC config when mutating webhook mode is nil
 	obj = clusterRoleObj.DeepCopy()
-	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false)
+	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1201,7 +1233,7 @@ func TestMutationRBACConfig(t *testing.T) {
 	obj = clusterRoleObj.DeepCopy()
 	mutation := operatorv1alpha1.WebhookDisabled
 	gatekeeper.Spec.MutatingWebhook = &mutation
-	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false)
+	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1220,7 +1252,7 @@ func TestMutationRBACConfig(t *testing.T) {
 	obj = clusterRoleObj.DeepCopy()
 	mutation = operatorv1alpha1.WebhookEnabled
 	gatekeeper.Spec.MutatingWebhook = &mutation
-	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false)
+	err = crOverrides(gatekeeper, ClusterRoleFile, obj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
 	rules, found, err = unstructured.NestedSlice(obj.Object, "rules")
 	g.Expect(err).ToNot(HaveOccurred())

--- a/controllers/merge/merge.go
+++ b/controllers/merge/merge.go
@@ -39,6 +39,8 @@ func RetainClusterObjectFields(desiredObj, clusterObj *unstructured.Unstructured
 		fallthrough
 	case util.MutatingWebhookConfigurationKind:
 		return retainWebhookConfigurationFields(desiredObj, clusterObj)
+	case util.SecretKind:
+		return retainSecretFields(desiredObj, clusterObj)
 	default:
 		return nil
 	}
@@ -56,6 +58,19 @@ func retainServiceFields(desiredObj, clusterObj *unstructured.Unstructured) erro
 		}
 	} // !ok could indicate that a clusterIP was not assigned
 
+	return nil
+}
+
+func retainSecretFields(desiredObj, clusterObj *unstructured.Unstructured) error {
+	data, ok, err := unstructured.NestedMap(clusterObj.Object, "data")
+	if err != nil {
+		return errors.Wrap(err, "Error retrieving data from secret")
+	} else if ok && len(data) != 0 {
+		err := unstructured.SetNestedMap(desiredObj.Object, data, "data")
+		if err != nil {
+			return errors.Wrap(err, "Error setting data for secret")
+		}
+	}
 	return nil
 }
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -18,4 +18,5 @@ const (
 	ServiceKind                        = "Service"
 	ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
 	MutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"
+	SecretKind                         = "Secret"
 )

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,12 +17,17 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +46,8 @@ import (
 var cfg *rest.Config
 var K8sClient client.Client
 var testEnv *envtest.Environment
+var affinityPod *corev1.Pod
+var affinityNode *corev1.Node
 
 func RunE2ETests(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -75,11 +82,72 @@ var _ = BeforeSuite(func(done Done) {
 	err = extv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	affinityNode, err = getAffinityNode()
+	Expect(err).ToNot(HaveOccurred())
+
+	if affinityNode != nil {
+		Expect(labelNode(affinityNode)).Should(Succeed())
+	}
 	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+
+	if affinityNode != nil {
+		K8sClient.Delete(ctx, affinityPod, client.PropagationPolicy(v1.DeletePropagationForeground))
+		Expect(unlabelNode(affinityNode)).Should(Succeed())
+		err := deleteAffinityPod()
+		Expect(err).ToNot(HaveOccurred())
+	}
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
+
+func getAffinityNode() (*corev1.Node, error) {
+	nodes := &corev1.NodeList{}
+	err := K8sClient.List(context.TODO(), nodes)
+	if err != nil {
+		return nil, err
+	}
+	// If true, we use a testEnv
+	if len(nodes.Items) == 0 {
+		return nil, nil
+	}
+	return &nodes.Items[0], nil
+}
+
+func labelNode(node *corev1.Node) error {
+	patch := client.MergeFrom(node.DeepCopy())
+	node.ObjectMeta.Labels["region"] = "EMEA"
+	node.ObjectMeta.Labels["topology.kubernetes.io/zone"] = "test"
+	return K8sClient.Patch(context.TODO(), node, patch)
+}
+
+func unlabelNode(node *corev1.Node) error {
+	patch := client.MergeFrom(node.DeepCopy())
+	delete(node.ObjectMeta.Labels, "region")
+	delete(node.ObjectMeta.Labels, "topology.kubernetes.io/zone")
+	return K8sClient.Patch(context.TODO(), node, patch)
+}
+
+func deleteAffinityPod() error {
+	affinityPodFromFile, err := loadAffinityPodFromFile(gkNamespace)
+	if err != nil {
+		return err
+	}
+
+	affinityPodName := types.NamespacedName{
+		Namespace: affinityPodFromFile.ObjectMeta.Namespace,
+		Name:      affinityPodFromFile.ObjectMeta.Name,
+	}
+	pod := &corev1.Pod{}
+	err = K8sClient.Get(ctx, affinityPodName, pod)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return K8sClient.Delete(ctx, pod)
+}

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -46,9 +46,9 @@ import (
 
 const (
 	// The length of time between polls.
-	pollInterval = time.Second
+	pollInterval = 50 * time.Millisecond
 	// How long to try before giving up.
-	waitTimeout = 60 * time.Second
+	waitTimeout = 30 * time.Second
 	// Longer try before giving up.
 	longWaitTimeout = waitTimeout * 4
 	// Gatekeeper name and namespace


### PR DESCRIPTION
Deploying webhooks with a non Ignore failure policy can negatively affect the stability of the cluster if the deployment backing it fails. This PR causes the webhooks to be created with an Ignore failure policy, and changes it to the desired value once the gatekeeper controller deployment is fully operational