### PR TITLE
Fix CI errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -90,7 +90,9 @@ jobs:
         make e2e-bootstrap
 
     - name: Create K8s KinD Cluster
-      run: kind create cluster --image kindest/node:v1.19.7
+      run: |
+        kind version
+        kind create cluster --image kindest/node:v1.19.7
 
     - name: Build and Push Test Container Image to KIND node
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   main:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [ '1.15' ]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,6 +83,12 @@ jobs:
         make bundle
         git diff --exit-code
 
+    - name: Bootstrap e2e
+      run: |
+        mkdir -p ${GITHUB_WORKSPACE}/bin
+        echo "${GITHUB_WORKSPACE}/bin" >> ${GITHUB_PATH}
+        make e2e-bootstrap
+
     - name: Create K8s KinD Cluster
       run: kind create cluster --image kindest/node:v1.19.7
 

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [ '1.15' ]

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [ '1.15' ]

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: Bootstrap e2e
+      run: |
+        mkdir -p ${GITHUB_WORKSPACE}/bin
+        echo "${GITHUB_WORKSPACE}/bin" >> ${GITHUB_PATH}
+        make e2e-bootstrap
+
     - name: Create and set up K8s KinD Cluster
       run: |
         ./scripts/kind-with-registry.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Create Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [ '1.15' ]

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ else
 OPERATOR_SDK=$(shell which operator-sdk)
 endif
 
+# kind variables
+KIND_VERSION ?= 0.10.0
+
 # Use the vendored directory
 GOFLAGS = -mod=vendor
 
@@ -341,6 +344,11 @@ tidy:
 .PHONY: test-cluster
 test-cluster:
 	./scripts/kind-with-registry.sh
+
+.PHONY: e2e-bootstrap
+e2e-bootstrap:
+	# Download and install kind
+	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
 
 .PHONY: test-gatekeeper-e2e
 test-gatekeeper-e2e:

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ $(OPM):
 	export GOPATH=$${OPM_GEN_TMP_DIR} ;\
 	go get github.com/operator-framework/operator-registry || true;\
 	cd src/github.com/operator-framework/operator-registry ;\
-	git checkout -b v1.15.1 ;\
+	git checkout v1.15.1 ;\
 	make bin/opm ;\
 	mv bin/opm $@ ;\
 	rm -rf $$OPM_GEN_TMP_DIR ;\

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -14,6 +14,8 @@ if [ "${running}" != 'true' ]; then
     registry:2
 fi
 
+kind version
+
 # create a cluster with the local registry enabled in containerd
 cat <<EOF | kind create cluster --image kindest/node:v1.19.7 --name "${KIND_CLUSTER_NAME}" --config=-
 kind: Cluster

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -30,11 +30,11 @@ teardown_file() {
   CLEAN_CMD="${CLEAN_CMD}; rm ${cert}"
   wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "get_ca_cert ${cert}"
 
-  kubectl run temp --generator=run-pod/v1  --image=tutum/curl -- tail -f /dev/null
+  kubectl run temp --image=curlimages/curl -- tail -f /dev/null
   kubectl wait --for=condition=Ready --timeout=60s pod temp
-  kubectl cp ${cert} temp:/cacert
+  kubectl cp ${cert} temp:/tmp/cacert
 
-  wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl exec -it temp -- curl -f --cacert /cacert --connect-timeout 1 --max-time 2  https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admitlabel"
+  wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl exec -it temp -- curl -f --cacert /tmp/cacert --connect-timeout 1 --max-time 2  https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admitlabel"
   kubectl delete pod temp
 }
 
@@ -136,7 +136,7 @@ teardown_file() {
 }
 
 @test "waiting for namespaces to be synced using metrics endpoint" {
-  kubectl run temp --generator=run-pod/v1  --image=tutum/curl -- tail -f /dev/null
+  kubectl run temp --image=curlimages/curl -- tail -f /dev/null
   kubectl wait --for=condition=Ready --timeout=60s pod temp
 
   num_namespaces=$(kubectl get ns -o json | jq '.items | length')

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -50,7 +50,7 @@ const (
 	// How long to try before giving up.
 	waitTimeout = 1 * time.Minute
 	// Longer try before giving up.
-	longWaitTimeout = waitTimeout * 4
+	longWaitTimeout = waitTimeout * 5
 	// Gatekeeper name and namespace
 	gkName                      = "gatekeeper"
 	gatekeeperWithAllValuesFile = "gatekeeper_with_all_values.yaml"


### PR DESCRIPTION
 - Fix OPM build error. This was caused by using the -b option to create and checkout a new branch. Removing the -b option instead checks out the v1.15.1 tag in detached HEAD state.
 - Increase long timeout to 5 minutes
 - Update GitHub Actions hosted runner OS to latest ubuntu-20.04
 - Fix culr image in bats test
 - Output kind version in CI for debug purposes
