### PR TITLE
Do not skip creating the namespace asset in kubernetes

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -126,6 +126,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - mutations.gatekeeper.sh
           resources:
           - '*'
@@ -229,18 +241,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - security.openshift.io
           resourceNames:

--- a/config/rbac/base/role.yaml
+++ b/config/rbac/base/role.yaml
@@ -83,6 +83,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - mutations.gatekeeper.sh
   resources:
   - '*'

--- a/config/rbac/overlays/openshift/kustomization.yaml
+++ b/config/rbac/overlays/openshift/kustomization.yaml
@@ -11,21 +11,6 @@ patchesJSON6902:
       path: /rules/-
       value:
         apiGroups:
-          - ""
-        resources:
-          - namespaces
-        verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-    - op: add
-      path: /rules/-
-      value:
-        apiGroups:
           - security.openshift.io
         resourceNames:
           - anyuid

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -120,7 +120,7 @@ const (
 	delete crudOperation = iota
 )
 
-// Gatekeeper Operator RBAC permissions to manager Gatekeeper custom resource
+// Gatekeeper Operator RBAC permissions to manage Gatekeeper custom resource
 // +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.gatekeeper.sh,resources=gatekeepers/finalizers,verbs=delete;get;update;patch
@@ -131,6 +131,7 @@ const (
 
 // Cluster Scoped
 // +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.gatekeeper.sh,resources=configs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.gatekeeper.sh,resources=configs/status,verbs=get;update;patch

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -263,14 +263,7 @@ func (r *GatekeeperReconciler) deployGatekeeperResources(gatekeeper *operatorv1a
 }
 
 func (r *GatekeeperReconciler) applyAsset(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, controllerDeploymentPending bool) error {
-	// Handle special cases in switch below.
-	switch {
-	case asset == NamespaceFile && !r.isOpenShift():
-		// Ignore the namespace resource on Kubernetes as we default to use
-		// the same namespace as the operator, which by definition is
-		// already created as a result of executing this code.
-		return nil
-	case asset == RoleFile && r.isOpenShift():
+	if asset == RoleFile && r.isOpenShift() {
 		asset = openshiftAssetsDir + asset
 	}
 
@@ -396,9 +389,14 @@ func (r *GatekeeperReconciler) crudResource(obj *unstructured.Unstructured, gate
 
 	logger := r.Log.WithValues("Gatekeeper resource", namespacedName)
 
-	err = ctrl.SetControllerReference(gatekeeper, obj, r.Scheme)
-	if err != nil {
-		return errors.Wrapf(err, "Unable to set controller reference for %s", namespacedName)
+	// Skip adding a controller reference for the namespace so that a deletion
+	// of the Gatekeeper CR does not also delete the namespace and everything
+	// within it.
+	if obj.GetKind() != util.NamespaceKind {
+		err = ctrl.SetControllerReference(gatekeeper, obj, r.Scheme)
+		if err != nil {
+			return errors.Wrapf(err, "Unable to set controller reference for %s", namespacedName)
+		}
 	}
 
 	err = r.Get(ctx, namespacedName, clusterObj)

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -15,6 +15,7 @@ limitations under the License.
 package util
 
 const (
+	NamespaceKind                      = "Namespace"
 	ServiceKind                        = "Service"
 	ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
 	MutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"


### PR DESCRIPTION
- Add RBAC permission to operator to CRUD namespaces
- Remove RBAC patch operation in OpenShift overlay
- make manifests
- Do not skip creating the Namespace asset

Closes #169 
