### PR TITLE
Add -delete-timeout flag to e2e tests and override defaults in e2e CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ test: generate fmt vet manifests
 
 .PHONY: test-e2e
 test-e2e: generate fmt vet
-	GOFLAGS=$(GOFLAGS) USE_EXISTING_CLUSTER=true go test -v ./test/e2e -coverprofile cover.out -race -args -ginkgo.v -ginkgo.progress -ginkgo.trace -namespace $(NAMESPACE)
+	GOFLAGS=$(GOFLAGS) USE_EXISTING_CLUSTER=true go test -v ./test/e2e -coverprofile cover.out -race -args -ginkgo.v -ginkgo.progress -ginkgo.trace -namespace $(NAMESPACE) -timeout 5m -delete-timeout 10m
 
 .PHONY: deploy-olm
 deploy-olm:

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -132,13 +132,13 @@ func unlabelNode(node *corev1.Node) error {
 }
 
 func createAffinityPod() {
-	affinityPod, err := loadAffinityPodFromFile(*GatekeeperNamespace)
+	affinityPod, err := loadAffinityPodFromFile(GatekeeperNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(K8sClient.Create(ctx, affinityPod)).Should(Succeed())
 }
 
 func deleteAffinityPod() error {
-	affinityPodFromFile, err := loadAffinityPodFromFile(*GatekeeperNamespace)
+	affinityPodFromFile, err := loadAffinityPodFromFile(GatekeeperNamespace)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -132,13 +132,13 @@ func unlabelNode(node *corev1.Node) error {
 }
 
 func createAffinityPod() {
-	affinityPod, err := loadAffinityPodFromFile(GatekeeperNamespace)
+	affinityPod, err := loadAffinityPodFromFile(gatekeeperNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(K8sClient.Create(ctx, affinityPod)).Should(Succeed())
 }
 
 func deleteAffinityPod() error {
-	affinityPodFromFile, err := loadAffinityPodFromFile(GatekeeperNamespace)
+	affinityPodFromFile, err := loadAffinityPodFromFile(gatekeeperNamespace)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -310,7 +310,7 @@ var _ = Describe("Gatekeeper", func() {
 				gkDeployment := &appsv1.Deployment{}
 				Eventually(func() (int32, error) {
 					return getDeploymentReadyReplicas(ctx, controllerManagerName, gkDeployment)
-				}, Timeout*5, PollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
+				}, Timeout, PollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
 			})
 
 			By("Checking webhook is available", func() {

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -63,7 +63,7 @@ var (
 )
 
 func initializeGlobals() {
-	gkNamespace = GatekeeperNamespace
+	gkNamespace = gatekeeperNamespace
 	auditName = types.NamespacedName{
 		Namespace: gkNamespace,
 		Name:      "gatekeeper-audit",
@@ -105,7 +105,7 @@ var _ = Describe("Gatekeeper", func() {
 				return false
 			}
 			return apierrors.IsNotFound(err)
-		}, DeleteTimeout, PollInterval).Should(BeTrue())
+		}, deleteTimeout, pollInterval).Should(BeTrue())
 	})
 
 	Describe("Install", func() {
@@ -124,20 +124,20 @@ var _ = Describe("Gatekeeper", func() {
 				By("Checking gatekeeper-controller-manager readiness", func() {
 					Eventually(func() (int32, error) {
 						return getDeploymentReadyReplicas(ctx, controllerManagerName, gkDeployment)
-					}, Timeout, PollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
+					}, timeout, pollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
 				})
 
 				By("Checking gatekeeper-audit readiness", func() {
 					Eventually(func() (int32, error) {
 						return getDeploymentReadyReplicas(ctx, auditName, gkDeployment)
-					}, Timeout, PollInterval).Should(Equal(*gatekeeper.Spec.Audit.Replicas))
+					}, timeout, pollInterval).Should(Equal(*gatekeeper.Spec.Audit.Replicas))
 				})
 
 				By("Checking validatingWebhookConfiguration is deployed", func() {
 					validatingWebhookConfiguration := &admregv1.ValidatingWebhookConfiguration{}
 					Eventually(func() error {
 						return K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
-					}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+					}, timeout, pollInterval).ShouldNot(HaveOccurred())
 					Expect(validatingWebhookConfiguration.OwnerReferences).To(HaveLen(1))
 					Expect(validatingWebhookConfiguration.OwnerReferences[0].Kind).To(Equal("Gatekeeper"))
 					Expect(validatingWebhookConfiguration.OwnerReferences[0].Name).To(Equal(gkName))
@@ -310,7 +310,7 @@ var _ = Describe("Gatekeeper", func() {
 				gkDeployment := &appsv1.Deployment{}
 				Eventually(func() (int32, error) {
 					return getDeploymentReadyReplicas(ctx, controllerManagerName, gkDeployment)
-				}, Timeout, PollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
+				}, timeout, pollInterval).Should(Equal(*gatekeeper.Spec.Webhook.Replicas))
 			})
 
 			By("Checking webhook is available", func() {
@@ -484,7 +484,7 @@ func gatekeeperAuditDeployment() (auditDeployment *appsv1.Deployment) {
 	auditDeployment = &appsv1.Deployment{}
 	Eventually(func() error {
 		return K8sClient.Get(ctx, auditName, auditDeployment)
-	}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+	}, timeout, pollInterval).ShouldNot(HaveOccurred())
 	return
 }
 
@@ -492,7 +492,7 @@ func gatekeeperWebhookDeployment() (webhookDeployment *appsv1.Deployment) {
 	webhookDeployment = &appsv1.Deployment{}
 	Eventually(func() error {
 		return K8sClient.Get(ctx, controllerManagerName, webhookDeployment)
-	}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+	}, timeout, pollInterval).ShouldNot(HaveOccurred())
 	return
 }
 
@@ -508,7 +508,7 @@ func byCheckingValidationEnabled() {
 		validatingWebhookConfiguration := &admregv1.ValidatingWebhookConfiguration{}
 		Eventually(func() error {
 			return K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
-		}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+		}, timeout, pollInterval).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -519,28 +519,28 @@ func byCheckingMutationEnabled(auditDeployment, webhookDeployment *appsv1.Deploy
 		Eventually(func() bool {
 			_, found := getContainerArg(webhookDeployment.Spec.Template.Spec.Containers[0].Args, controllers.EnableMutationArg)
 			return found
-		}, Timeout, PollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue())
 	})
 
 	By(fmt.Sprintf("Checking %s=%s argument is set", controllers.OperationArg, controllers.OperationMutationStatus), func() {
 		Eventually(func() bool {
 			return findContainerArgValue(auditDeployment.Spec.Template.Spec.Containers[0].Args,
 				controllers.OperationArg, controllers.OperationMutationStatus)
-		}, Timeout, PollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue())
 	})
 
 	By("Checking MutatingWebhookConfiguration deployed", func() {
 		mutatingWebhookConfiguration := &admregv1.MutatingWebhookConfiguration{}
 		Eventually(func() error {
 			return K8sClient.Get(ctx, mutatingWebhookName, mutatingWebhookConfiguration)
-		}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+		}, timeout, pollInterval).ShouldNot(HaveOccurred())
 	})
 
 	var crdFn getCRDFunc
 	crdFn = func(crdName types.NamespacedName, mutatingCRD *extv1.CustomResourceDefinition) {
 		Eventually(func() error {
 			return K8sClient.Get(ctx, crdName, mutatingCRD)
-		}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+		}, timeout, pollInterval).ShouldNot(HaveOccurred())
 	}
 	byCheckingMutatingCRDs("deployed", crdFn)
 }
@@ -551,7 +551,7 @@ func byCheckingValidationDisabled() {
 		Eventually(func() bool {
 			err := K8sClient.Get(ctx, validatingWebhookName, validatingWebhookConfiguration)
 			return apierrors.IsNotFound(err)
-		}, Timeout, PollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue())
 	})
 }
 
@@ -561,7 +561,7 @@ func byCheckingMutationDisabled(auditDeployment, webhookDeployment *appsv1.Deplo
 			webhookDeployment = gatekeeperWebhookDeployment()
 			_, found := getContainerArg(webhookDeployment.Spec.Template.Spec.Containers[0].Args, controllers.EnableMutationArg)
 			return found
-		}, Timeout, PollInterval).Should(BeFalse())
+		}, timeout, pollInterval).Should(BeFalse())
 	})
 
 	By(fmt.Sprintf("Checking %s=%s argument is not set", controllers.OperationArg, controllers.OperationMutationStatus), func() {
@@ -570,7 +570,7 @@ func byCheckingMutationDisabled(auditDeployment, webhookDeployment *appsv1.Deplo
 			found := findContainerArgValue(auditDeployment.Spec.Template.Spec.Containers[0].Args,
 				controllers.OperationArg, controllers.OperationMutationStatus)
 			return found
-		}, Timeout, PollInterval).Should(BeFalse())
+		}, timeout, pollInterval).Should(BeFalse())
 	})
 
 	By("Checking MutatingWebhookConfiguration not deployed", func() {
@@ -578,7 +578,7 @@ func byCheckingMutationDisabled(auditDeployment, webhookDeployment *appsv1.Deplo
 		Eventually(func() bool {
 			err := K8sClient.Get(ctx, mutatingWebhookName, mutatingWebhookConfiguration)
 			return apierrors.IsNotFound(err)
-		}, Timeout, PollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue())
 	})
 
 	var crdFn getCRDFunc
@@ -586,7 +586,7 @@ func byCheckingMutationDisabled(auditDeployment, webhookDeployment *appsv1.Deplo
 		Eventually(func() bool {
 			err := K8sClient.Get(ctx, crdName, mutatingCRD)
 			return apierrors.IsNotFound(err)
-		}, Timeout, PollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue())
 	}
 	byCheckingMutatingCRDs("not deployed", crdFn)
 }
@@ -614,7 +614,7 @@ func byCheckingFailurePolicy(webhookNamespacedName *types.NamespacedName,
 		webhookConfiguration.SetKind(kind)
 		Eventually(func() error {
 			return K8sClient.Get(ctx, *webhookNamespacedName, webhookConfiguration)
-		}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+		}, timeout, pollInterval).ShouldNot(HaveOccurred())
 		assertFailurePolicy(webhookConfiguration, webhookName, failurePolicy)
 	})
 }
@@ -633,7 +633,7 @@ func byCheckingNamespaceSelector(webhookNamespacedName *types.NamespacedName,
 		webhookConfiguration.SetKind(kind)
 		Eventually(func() error {
 			return K8sClient.Get(ctx, *webhookNamespacedName, webhookConfiguration)
-		}, Timeout, PollInterval).ShouldNot(HaveOccurred())
+		}, timeout, pollInterval).ShouldNot(HaveOccurred())
 		assertNamespaceSelector(webhookConfiguration, webhookName, namespaceSelector)
 	})
 }

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -52,7 +52,6 @@ const (
 var (
 	ctx                   = context.Background()
 	globalsInitialized    = false
-	gkNamespace           = ""
 	auditName             = types.NamespacedName{}
 	controllerManagerName = types.NamespacedName{}
 	gatekeeperName        = types.NamespacedName{
@@ -63,21 +62,20 @@ var (
 )
 
 func initializeGlobals() {
-	gkNamespace = gatekeeperNamespace
 	auditName = types.NamespacedName{
-		Namespace: gkNamespace,
+		Namespace: gatekeeperNamespace,
 		Name:      "gatekeeper-audit",
 	}
 	controllerManagerName = types.NamespacedName{
-		Namespace: gkNamespace,
+		Namespace: gatekeeperNamespace,
 		Name:      "gatekeeper-controller-manager",
 	}
 	validatingWebhookName = types.NamespacedName{
-		Namespace: gkNamespace,
+		Namespace: gatekeeperNamespace,
 		Name:      "gatekeeper-validating-webhook-configuration",
 	}
 	mutatingWebhookName = types.NamespacedName{
-		Namespace: gkNamespace,
+		Namespace: gatekeeperNamespace,
 		Name:      "gatekeeper-mutating-webhook-configuration",
 	}
 }
@@ -112,7 +110,7 @@ var _ = Describe("Gatekeeper", func() {
 		Context("Creating Gatekeeper custom resource", func() {
 			It("Should install Gatekeeper", func() {
 				gatekeeper := &v1alpha1.Gatekeeper{}
-				gatekeeper.Namespace = gkNamespace
+				gatekeeper.Namespace = gatekeeperNamespace
 				err := loadGatekeeperFromFile(gatekeeper, "operator_v1alpha1_gatekeeper.yaml")
 				Expect(err).ToNot(HaveOccurred())
 				gkDeployment := &appsv1.Deployment{}
@@ -257,7 +255,7 @@ var _ = Describe("Gatekeeper", func() {
 
 		It("Contains the configured values", func() {
 			gatekeeper := &v1alpha1.Gatekeeper{}
-			gatekeeper.Namespace = gkNamespace
+			gatekeeper.Namespace = gatekeeperNamespace
 			err := loadGatekeeperFromFile(gatekeeper, gatekeeperWithAllValuesFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
@@ -742,7 +740,7 @@ func emptyGatekeeper() *v1alpha1.Gatekeeper {
 	return &v1alpha1.Gatekeeper{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      gkName,
-			Namespace: gkNamespace,
+			Namespace: gatekeeperNamespace,
 		},
 	}
 }

--- a/test/e2e/gatekeeper_controller.go
+++ b/test/e2e/gatekeeper_controller.go
@@ -105,7 +105,7 @@ var _ = Describe("Gatekeeper", func() {
 				return false
 			}
 			return apierrors.IsNotFound(err)
-		}, *Timeout*10, *PollInterval).Should(BeTrue())
+		}, DeleteTimeout, PollInterval).Should(BeTrue())
 	})
 
 	Describe("Install", func() {

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -23,7 +23,14 @@ import (
 	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
 )
 
-var GatekeeperNamespace = *flag.String("namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
-var PollInterval = *flag.Duration("poll-interval", 1*time.Second, "The length of time between polls")
-var Timeout = *flag.Duration("timeout", 1*time.Minute, "The length of time to poll before giving up")
-var DeleteTimeout = *flag.Duration("delete-timeout", 5*time.Minute, "The length of time to wait for deletion of all resources")
+var GatekeeperNamespace string
+var PollInterval time.Duration
+var Timeout time.Duration
+var DeleteTimeout time.Duration
+
+func init() {
+	flag.StringVar(&GatekeeperNamespace, "namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
+	flag.DurationVar(&PollInterval, "poll-interval", 1*time.Second, "The length of time between polls")
+	flag.DurationVar(&Timeout, "timeout", 1*time.Minute, "The length of time to poll before giving up")
+	flag.DurationVar(&DeleteTimeout, "delete-timeout", 5*time.Minute, "The length of time to wait for deletion of all resources")
+}

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -26,3 +26,4 @@ import (
 var GatekeeperNamespace = *flag.String("namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
 var PollInterval = *flag.Duration("poll-interval", 1*time.Second, "The length of time between polls")
 var Timeout = *flag.Duration("timeout", 1*time.Minute, "The length of time to poll before giving up")
+var DeleteTimeout = *flag.Duration("delete-timeout", 5*time.Minute, "The length of time to wait for deletion of all resources")

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -23,6 +23,6 @@ import (
 	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
 )
 
-var GatekeeperNamespace = flag.String("namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
-var PollInterval = flag.Duration("poll-interval", 1*time.Second, "The length of time between polls")
-var Timeout = flag.Duration("timeout", 1*time.Minute, "The length of time to poll before giving up")
+var GatekeeperNamespace = *flag.String("namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
+var PollInterval = *flag.Duration("poll-interval", 1*time.Second, "The length of time between polls")
+var Timeout = *flag.Duration("timeout", 1*time.Minute, "The length of time to poll before giving up")

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -23,14 +23,14 @@ import (
 	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
 )
 
-var GatekeeperNamespace string
-var PollInterval time.Duration
-var Timeout time.Duration
-var DeleteTimeout time.Duration
+var gatekeeperNamespace string
+var pollInterval time.Duration
+var timeout time.Duration
+var deleteTimeout time.Duration
 
 func init() {
-	flag.StringVar(&GatekeeperNamespace, "namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
-	flag.DurationVar(&PollInterval, "poll-interval", 1*time.Second, "The length of time between polls")
-	flag.DurationVar(&Timeout, "timeout", 1*time.Minute, "The length of time to poll before giving up")
-	flag.DurationVar(&DeleteTimeout, "delete-timeout", 5*time.Minute, "The length of time to wait for deletion of all resources")
+	flag.StringVar(&gatekeeperNamespace, "namespace", util.DefaultGatekeeperNamespace, "The namespace to run tests")
+	flag.DurationVar(&pollInterval, "poll-interval", 1*time.Second, "The length of time between polls")
+	flag.DurationVar(&timeout, "timeout", 1*time.Minute, "The length of time to poll before giving up")
+	flag.DurationVar(&deleteTimeout, "delete-timeout", 5*time.Minute, "The length of time to wait for deletion of all resources")
 }


### PR DESCRIPTION
- Remove need for pointer dereference
- Reduce check ready replicas timeout to default
- Add -delete-timeout flag for e2e tests
- Set e2e timeout flags for Makefile test-e2e target
