### PR TITLE
Update operator Deployment name

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -263,7 +263,7 @@ spec:
           - create
         serviceAccountName: default
       deployments:
-      - name: gatekeeper-operator-controller-manager
+      - name: gatekeeper-operator-controller
         spec:
           replicas: 1
           selector:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controller
   namespace: system
   labels:
     control-plane: controller-manager


### PR DESCRIPTION
This update makes the operator's Deployment name unique from the
previous version of the operator so that we can update the labels for
the operator's Deployment. Updating the labels is essential so that we
can avoid duplicating labels with the Gatekeeper resources as Gatekeeper
is also using the default 'control-plane: controller-manager' label in
its Deployments, Service, Namespace, and PolicyDisruptionBudget
resources. Otherwise it inhibits filtering output based on this label if
the label is identical between both the operator and Gatekeeper.

The labels field is an immutable field, so the only way to update the
label is to create a new Deployment with a different name. This loses
some of the rolling upgrade features of Deployments, but OLM will
properly cleanup the old Deployment. Without OLM, the user will need to
manually delete the Deployment for the previous version of the operator
that is installed. Rolling upgrades is not a critical feature for this
operator at this time.
