### PR TITLE
Update Operator to support Gatekeeper v3.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION ?= v0.2.0-rc.0
 # Replaces Operator version
 REPLACES_VERSION ?= $(VERSION)
 # Current Gatekeeper version
-GATEKEEPER_VERSION ?= v3.5.1
+GATEKEEPER_VERSION ?= v3.5.2
 # Default image repo
 REPO ?= quay.io/gatekeeper
 # Default bundle image tag

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -282,7 +282,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_GATEKEEPER
-                  value: openpolicyagent/gatekeeper:v3.5.1
+                  value: openpolicyagent/gatekeeper:v3.5.2
                 image: quay.io/gatekeeper/gatekeeper-operator:v0.2.0-rc.0
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
@@ -41,7 +41,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.5.1
+        image: openpolicyagent/gatekeeper:v3.5.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
@@ -54,7 +54,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.5.1
+        image: openpolicyagent/gatekeeper:v3.5.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,5 +55,5 @@ spec:
             memory: 20Mi
         env:
         - name: RELATED_IMAGE_GATEKEEPER
-          value: openpolicyagent/gatekeeper:v3.5.1
+          value: openpolicyagent/gatekeeper:v3.5.2
       terminationGracePeriodSeconds: 10

--- a/config/samples/gatekeeper_with_all_values.yaml
+++ b/config/samples/gatekeeper_with_all_values.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   # Add fields here
   image:
-    image: docker.io/openpolicyagent/gatekeeper:v3.5.1
+    image: docker.io/openpolicyagent/gatekeeper:v3.5.2
     imagePullPolicy: Always
   audit:
     replicas: 1

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -1438,7 +1438,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.5.1
+        image: openpolicyagent/gatekeeper:v3.5.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -1550,7 +1550,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.5.1
+        image: openpolicyagent/gatekeeper:v3.5.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
- Set Gatekeeper version to v3.5.2
- Update deployed Gatekeeper image to v3.5.2
- Update sample configs to use Gatekeeper v3.5.2
- make import-manifests
- make update-bindata
- make bundle
