### PR TITLE
Move Go setup earlier in workflows

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -34,6 +34,11 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_TOKEN }}
 
+    - name: Set Up Go to Install OPM
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.7'
+
     - name: Build and Push Operator Image
       run: |
         make docker-build VERSION=master
@@ -43,11 +48,6 @@ jobs:
       run: |
         make bundle-build VERSION=master
         make docker-push IMG=${WORKFLOW_BUNDLE_IMG}:master
-
-    - name: Set Up Go to Install OPM
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.16.7'
 
     - name: Build and Push Bundle Index Image
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,11 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_TOKEN }}
 
+    - name: Set Up Go to Install OPM
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.7'
+
     - name: Build and Push Operator Image
       run: |
         make docker-build VERSION=${RELEASE_VERSION}
@@ -78,11 +83,6 @@ jobs:
         docker tag ${RELEASE_BUNDLE_IMG}:${RELEASE_VERSION} ${RELEASE_BUNDLE_IMG}:latest
         make docker-push IMG=${RELEASE_BUNDLE_IMG}:${RELEASE_VERSION}
         make docker-push IMG=${RELEASE_BUNDLE_IMG}:latest
-
-    - name: Set Up Go to Install OPM
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.16.7'
 
     - name: Build and Push Bundle Index Image
       run: |


### PR DESCRIPTION
The docker-build make target has other dependencies that use Go. Since
the specific version of Go was not set up until later in the Github
Action, I think the version it was using was whatever happened to
already be on that ubuntu VM. That could cause problems, possibly
including the recent image build failures.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>