### PR TITLE
[WIP] remove runAsNonRoot from csv

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -342,8 +342,6 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              securityContext:
-                runAsNonRoot: true
               serviceAccountName: gatekeeper-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      securityContext:
-        runAsNonRoot: true
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Specifying `runAsNonRoot` prevented install on OCP.