### PR TITLE
correct PR merge actions

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -51,6 +51,5 @@ jobs:
 
     - name: Build and Push Bundle Index Image
       run: |
-        PREV_BUNDLE_INDEX_IMG_VERSION=$(make prev-bundle-index-image-version)
-        make bundle-index-build VERSION=main REPLACES_VERSION=${PREV_BUNDLE_INDEX_IMG_VERSION}
+        make bundle-index-build VERSION=main
         make docker-push IMG=${WORKFLOW_BUNDLE_INDEX_IMG}:main

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -53,12 +53,12 @@ jobs:
       run: |
         # TODO: Use operator-sdk run bundle and bundle-upgrade commands for
         # testing with OLM.
-        PREV_BUNDLE_INDEX_IMG_VERSION=$(make prev-bundle-index-image-version)
+        REPLACES_VERSION=$(make get-replaces-version)
         OPERATOR_VERSION=$(awk '/^VERSION \?=/ {print $3}' Makefile)
         REPO=localhost:5000
         IMG=${REPO}/gatekeeper-operator:${GITHUB_SHA}
-        PREV_BUNDLE_INDEX_IMG=quay.io/gatekeeper/gatekeeper-operator-bundle-index:${PREV_BUNDLE_INDEX_IMG_VERSION}
-        make build-and-push-bundle-images IMG=${IMG} REPO=${REPO} VERSION=${GITHUB_SHA} OPERATOR_VERSION=${OPERATOR_VERSION} PREV_BUNDLE_INDEX_IMG=${PREV_BUNDLE_INDEX_IMG}
+        PREV_BUNDLE_INDEX_IMG=quay.io/gatekeeper/gatekeeper-operator-bundle-index:${REPLACES_VERSION}
+        make build-and-push-bundle-images IMG=${IMG} REPO=${REPO} VERSION=${GITHUB_SHA} OPERATOR_VERSION=${OPERATOR_VERSION}
 
     - name: Deploy OLM
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,8 +86,7 @@ jobs:
 
     - name: Build and Push Bundle Index Image
       run: |
-        PREV_BUNDLE_INDEX_IMG_VERSION=$(make prev-bundle-index-image-version)
-        make bundle-index-build VERSION=${RELEASE_VERSION} REPLACES_VERSION=${PREV_BUNDLE_INDEX_IMG_VERSION}
+        make bundle-index-build VERSION=${RELEASE_VERSION}
         docker tag ${RELEASE_BUNDLE_INDEX_IMG}:${RELEASE_VERSION} ${RELEASE_BUNDLE_INDEX_IMG}:latest
         make docker-push IMG=${RELEASE_BUNDLE_INDEX_IMG}:${RELEASE_VERSION}
         make docker-push IMG=${RELEASE_BUNDLE_INDEX_IMG}:latest

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ VERSION ?= 0.3.0-candidate.1
 # Replaces Operator version
 REPLACES_VERSION ?= none
 
+get-replaces-version:
+	@echo $(REPLACES_VERSION)
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -329,12 +332,6 @@ import-manifests: kustomize
 		$(KUSTOMIZE) build $(IMPORT_MANIFESTS_PATH)/config/overlays/mutation_webhook -o $(GATEKEEPER_MANIFEST_DIR); \
 		$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone $(IMPORT_MANIFESTS_PATH)/config/overlays/mutation -o $(GATEKEEPER_MANIFEST_DIR); \
 	fi
-
-# Get previous index image version
-.PHONY: prev-bundle-index-image-version
-prev-bundle-index-image-version:
-	@REPLACES=$$(grep replaces ./config/manifests/bases/gatekeeper-operator.clusterserviceversion.yaml); \
-	echo $${REPLACES#*.}
 
 # Build the bundle index image.
 .PHONY: bundle-index-build


### PR DESCRIPTION
Remove reliance on variables in favor of explicit Makefile setting for which version the bundle replaces