### PR TITLE
Fix the missing role file when deploying on OCP

### DIFF
--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -46,7 +46,6 @@ import (
 
 const (
 	defaultGatekeeperCrName           = "gatekeeper"
-	openshiftAssetsDir                = "openshift/"
 	GatekeeperImageEnvVar             = "RELATED_IMAGE_GATEKEEPER"
 	NamespaceFile                     = "v1_namespace_gatekeeper-system.yaml"
 	AssignCRDFile                     = "apiextensions.k8s.io_v1_customresourcedefinition_assign.mutations.gatekeeper.sh.yaml"
@@ -288,10 +287,6 @@ func (r *GatekeeperReconciler) applyAssets(assets []string, gatekeeper *operator
 }
 
 func (r *GatekeeperReconciler) applyAsset(gatekeeper *operatorv1alpha1.Gatekeeper, asset string, controllerDeploymentPending bool) error {
-	if asset == RoleFile && r.isOpenShift() {
-		asset = openshiftAssetsDir + asset
-	}
-
 	obj, err := util.GetManifestObject(asset)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previous versions of the Gatekeeper operator had a custom role definition for OpenShift but as part of the upgrade to v3.11, it was consolidated to a single role. It is benign to have an OpenShift specific permission on other clusters since that API group does not exist on other clusters. This keeps maintenance simpler.

Relates:
https://issues.redhat.com/browse/ACM-5295