### PR TITLE
Stop setting seccompProfile on the operator pods

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -367,8 +367,6 @@ spec:
                   capabilities:
                     drop:
                     - ALL
-                  seccompProfile:
-                    type: RuntimeDefault
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -405,8 +403,6 @@ spec:
                   capabilities:
                     drop:
                     - ALL
-                  seccompProfile:
-                    type: RuntimeDefault
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: gatekeeper-operator-controller-manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,8 +22,6 @@ spec:
           name: https
         securityContext:
           allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
           capabilities:
             drop:
             - ALL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,8 +34,6 @@ spec:
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
           capabilities:
             drop:
             - ALL

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1704,8 +1704,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
@@ -1742,8 +1740,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: gatekeeper-operator-controller-manager


### PR DESCRIPTION
This allows OpenShift to set the correct profile automatically for backwards compatibility with OCP 4.10.

Note in OpenShift 4.10, it sets the annotation `openshift.io/scc: restricted` on the pod when `seccompProfile` is unset. For OCP 4.13, it sets the annotation `openshift.io/scc: restricted-v2` on the pod when `seccompProfile` is unset.